### PR TITLE
ログイン前の共通ヘッダーを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,10 @@
   </head>
 
   <body>
-    <%= yield %>
+    <%= render "shared/header" %>
+
+    <main class="px-4">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,10 @@
+<header class="navbar bg-base-100 shadow-sm px-6">
+  <div class="flex-1">
+    <%= link_to "ごはん会議", root_path, class: "text-xl font-bold" %>
+  </div>
+
+  <div class="flex gap-2">
+    <%= link_to "新規登録", "#", class: "btn btn-primary btn-sm" %>
+    <%= link_to "ログイン", "#", class: "btn btn-outline btn-sm" %>
+  </div>
+</header>


### PR DESCRIPTION
## 概要
トップページ表示に必要なログイン前共通ヘッダーを実装した。
今後の拡張（ログイン後切り替え）を見据えて、ヘッダーはパーシャル化している。

## 内容
- 共通ヘッダー用パーシャルを作成 (app/views/shared/_header.html.erb)
- application.html.erb からヘッダーを読み込む
- ログイン前想定の表示項目を実装
   - アプリロゴ（root への導線）
   - 新規登録ボタン（仮リンク）
   - ログインボタン（仮リンク）

## 確認
- トップページを含む画面でヘッダーが表示されること
- ボタンが正しく表示されること

## 補足
- ログイン後の表示切り替えやメニュー（dropdown）は Sorcery 実装後に対応予定
- リンク先は現時点では仮

Close #21 