### PR TITLE
ログイン後トップ（ダッシュボード）画面を実装

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,4 @@
+class DashboardController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_to root_path, notice: "ログインしました"
+      redirect_to dashboard_path, notice: "ログインしました"
     else
       flash.now[:alert] = "メールアドレスまたはパスワードが違います"
       render :new, status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,10 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+
     if @user.save
-      redirect_to root_path, notice: "ユーザー登録しました"
+      auto_login(@user)
+      redirect_to dashboard_path, notice: "ユーザー登録しました"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,0 +1,2 @@
+module DashboardHelper
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,51 @@
+<div class="max-w-4xl mx-auto p-6">
+
+  <!-- ページタイトル（ダッシュボード表記なし） -->
+  <h1 class="text-2xl font-bold mb-6 text-center">
+    ごはん会議
+  </h1>
+
+  <!-- ユーザー情報 -->
+  <div class="mb-8 text-center">
+    <p class="text-gray-700">
+      ようこそ、
+      <span class="font-semibold">
+        <%= current_user.name %>
+      </span>
+      さん
+    </p>
+    <p class="text-sm text-gray-500 mt-1">
+      みんなで行くお店を決めましょう 🍽️
+    </p>
+  </div>
+
+  <!-- メイン導線 -->
+  <div class="grid gap-4 sm:grid-cols-2">
+
+    <!-- イベント作成 -->
+    <div class="card bg-base-100 shadow">
+      <div class="card-body">
+        <h2 class="card-title">イベントを作成</h2>
+        <p class="text-sm text-gray-600">
+          ランチ会・飲み会などの予定を作成できます
+        </p>
+        <div class="card-actions justify-end">
+          <%= link_to "イベントを作る", "#", class: "btn btn-primary" %>
+        </div>
+      </div>
+    </div>
+
+    <!-- イベント一覧 -->
+    <div class="card bg-base-100 shadow">
+      <div class="card-body">
+        <h2 class="card-title">イベント一覧</h2>
+        <p class="text-sm text-gray-600">
+          作成・参加しているイベントを確認できます
+        </p>
+        <div class="card-actions justify-end">
+          <%= link_to "一覧を見る", "#", class: "btn btn-outline" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
-  get 'user_sessions/new'
-  get 'users/new'
-  get 'users/create'
   root "static_pages#top"
+
+  get "dashboard", to: "dashboard#index"
 
   resources :users, only: %i[new create]
 

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DashboardControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get dashboard_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
ログイン後の起点となるトップ画面（ダッシュボード）を実装。
ログイン／新規登録後に遷移する画面を統一し、次の操作へ進みやすい導線を用意。

## 実装内容
- /dashboard へのルーティング追加
- DashboardsController#index を作成
- ログイン中ユーザー名の表示
- イベント作成／イベント一覧への導線配置（リンクは仮）
- 未ログイン時のアクセス制御（ログイン画面へリダイレクト）
- ログイン／新規登録後の遷移先を dashboard に統一

※ 導線リンクはイベント機能実装時に実リンクへ差し替え予定。

## 確認方法
- ログイン後にトップ画面が表示されること
- 未ログインで /dashboard にアクセスするとログイン画面に遷移すること

Close #37 