### PR TITLE
ログイン後ヘッダーのdropdownメニューを実装

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -47,5 +47,12 @@
         </div>
       </div>
     </div>
+
+    <div class="mt-8">
+      <%= link_to "ログアウト（確認用）",
+              logout_path,
+              data: { turbo_method: :delete },
+              class: "btn btn-error btn-sm" %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -1,0 +1,34 @@
+<header class="navbar bg-base-100 shadow-sm px-6">
+  <div class="flex-1">
+    <%= link_to "ごはん会議", dashboard_path, class: "text-xl font-bold" %>
+  </div>
+
+  <div class="flex items-center gap-3">
+    <div class="text-sm text-gray-600">
+      <%= current_user.name %> さん
+    </div>
+
+    <div class="dropdown dropdown-end">
+      <label tabindex="0" class="btn btn-ghost btn-circle">
+        <!-- ハンバーガー -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
+             viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </label>
+
+      <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+        <li><%= link_to "トップ", dashboard_path %></li>
+        <li><%= link_to "イベント作成（仮）", "#" %></li>
+        <li><%= link_to "イベント一覧（仮）", "#" %></li>
+        <li>
+          <%= link_to "ログアウト",
+                      logout_path,
+                      data: { turbo_method: :delete },
+                      class: "text-error hover:bg-base-200" %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</header>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,10 @@
+<header class="navbar bg-base-100 shadow-sm px-6">
+  <div class="flex-1">
+    <%= link_to "ごはん会議", root_path, class: "text-xl font-bold" %>
+  </div>
+
+  <div class="flex gap-2">
+    <%= link_to "新規登録", new_user_path, class: "btn btn-primary btn-sm" %>
+    <%= link_to "ログイン", login_path, class: "btn btn-outline btn-sm" %>
+  </div>
+</header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,10 +1,5 @@
-<header class="navbar bg-base-100 shadow-sm px-6">
-  <div class="flex-1">
-    <%= link_to "ごはん会議", root_path, class: "text-xl font-bold" %>
-  </div>
-
-  <div class="flex gap-2">
-    <%= link_to "新規登録", "#", class: "btn btn-primary btn-sm" %>
-    <%= link_to "ログイン", "#", class: "btn btn-outline btn-sm" %>
-  </div>
-</header>
+<% if logged_in? %>
+  <%= render "shared/after_login_header" %>
+<% else %>
+  <%= render "shared/before_login_header" %>
+<% end %>


### PR DESCRIPTION
## 概要
ログイン前・ログイン後で表示が切り替わる共通ヘッダーを実装。  
ログイン後は dropdown メニューから主要画面へ遷移できるようにしている。

## 実装内容
- 共通ヘッダーを partial 化
- ログイン状態による表示切り替え
- 未ログイン時：新規登録 / ログインボタンを表示
- ログイン時：メニューボタン（dropdown）を表示
- dropdown メニュー項目（※仮リンク含む）
  - ダッシュボード
  - イベント作成（仮）
  - 作成イベント一覧（仮）
  - 参加イベント一覧（仮）
  - ログアウト

## 動作確認
- [x] 未ログイン状態で `/` にアクセスすると、新規登録・ログインボタンが表示される
- [x] ログイン後に `/dashboard` にアクセスすると、ログイン後ヘッダーが表示される
- [x] メニューボタンをクリックすると dropdown が開閉できる
- [x] ログアウトをクリックするとログアウトでき、ログイン前ヘッダーに戻る

## 補足
- 実際の遷移先は今後のイベント機能実装時に対応予定

Close #33 