### PR TITLE
イベント作成機能の実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,22 @@
+class EventsController < ApplicationController
+  def new
+    @event = Event.new
+  end
+
+  def create
+    @event = current_user.events.new(event_params)
+
+    if @event.save
+      redirect_to dashboard_path, notice: "イベントを作成しました"
+    else
+      flash.now[:alert] = "入力内容を確認してください"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:title, :event_date, :event_time, :place)
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,15 @@
+class Event < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :event_date, presence: true
+  validates :unique_url, presence: true, uniqueness: true, length: { maximum: 255 }
+
+  before_validation :set_unique_url, on: :create
+
+  private
+
+  def set_unique_url
+    self.unique_url ||= SecureRandom.urlsafe_base64(10)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,5 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true,
             if: -> { new_record? || changes[:crypted_password] }
   
+  has_many :events, dependent: :destroy
 end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,55 @@
+<div class="max-w-xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-2">イベント作成</h1>
+  <p class="text-sm text-gray-500 mb-6">
+    日程や場所を入力して、イベントを作成します。
+  </p>
+
+  <% if @event.errors.any? %>
+    <div class="alert alert-error mb-6">
+      <div>
+        <p class="font-semibold">入力内容を確認してください</p>
+        <ul class="list-disc ml-5 text-sm mt-2">
+          <% @event.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <%= form_with model: @event, url: events_path do |f| %>
+    <!-- イベント名 -->
+    <div class="form-control mb-4">
+      <%= f.label :title, "イベント名", class: "label" %>
+      <%= f.text_field :title,
+            class: "input input-bordered w-full",
+            placeholder: "金曜ランチ会" %>
+    </div>
+
+    <!-- 開催日 -->
+    <div class="form-control mb-4">
+      <%= f.label :event_date, "開催日", class: "label" %>
+      <%= f.date_field :event_date, class: "input input-bordered w-full" %>
+    </div>
+
+    <!-- 開始時間（任意） -->
+    <div class="form-control mb-4">
+      <%= f.label :event_time, "開始時間（任意）", class: "label" %>
+      <%= f.time_field :event_time, class: "input input-bordered w-full" %>
+    </div>
+
+    <!-- 場所（任意） -->
+    <div class="form-control mb-6">
+      <%= f.label :place, "場所（任意）", class: "label" %>
+      <%= f.text_field :place,
+            class: "input input-bordered w-full",
+            placeholder: "新宿 / 東京駅周辺 など" %>
+    </div>
+
+    <%= f.submit "作成する", class: "btn btn-primary w-full" %>
+
+    <div class="mt-3 text-center">
+      <%= link_to "戻る", dashboard_path, class: "link link-hover text-sm text-gray-500" %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root "static_pages#top"
 
+  resources :events, only: %i[new create]
+
   get "dashboard", to: "dashboard#index"
 
   resources :users, only: %i[new create]

--- a/db/migrate/20260120142514_create_events.rb
+++ b/db/migrate/20260120142514_create_events.rb
@@ -1,0 +1,16 @@
+class CreateEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.date :event_date, null: false
+      t.time :event_time
+      t.string :place
+      t.string :unique_url, null: false
+
+      t.timestamps
+    end
+
+    add_index :events, :unique_url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_14_161004) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_20_142514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.date "event_date", null: false
+    t.time "event_time"
+    t.string "place"
+    t.string "unique_url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["unique_url"], name: "index_events_on_unique_url", unique: true
+    t.index ["user_id"], name: "index_events_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -24,4 +37,5 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_14_161004) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "events", "users"
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get events_new_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  title: MyString
+  event_date: 2026-01-20
+  event_time: 2026-01-20 23:25:14
+  place: MyString
+  unique_url: MyString
+
+two:
+  user: two
+  title: MyString
+  event_date: 2026-01-20
+  event_time: 2026-01-20 23:25:14
+  place: MyString
+  unique_url: MyString

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ログイン中のユーザーがイベントを作成できる機能を実装。

## 実装内容
- Eventモデルの作成
- eventsテーブルの作成（user_id を含む）
- User と Event のアソシエーション設定
- EventsController に new / create アクションを追加
- イベント作成用ルーティングの設定（new / create）
- イベント作成フォームの実装（ER図に基づいた項目）
- Eventモデルにバリデーションを設定
- current_user に紐づけてイベントを保存
- 作成後にダッシュボードへリダイレクト
- フラッシュメッセージの表示

## 動作確認
- ログイン中に /events/new にアクセスするとイベント作成フォームが表示されること
- 必須項目未入力時にバリデーションエラーが表示されること
- 正常入力時にイベントが作成されること
- 作成されたイベントが current_user に紐づいて保存されていること
- 作成後にダッシュボードへ遷移し、フラッシュメッセージが表示されること

## 補足
- unique_url は before_validation で自動生成

Close #8