### PR TITLE
イベント作成画面への導線を追加

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -30,7 +30,7 @@
           ランチ会・飲み会などの予定を作成できます
         </p>
         <div class="card-actions justify-end">
-          <%= link_to "イベントを作る", "#", class: "btn btn-primary" %>
+          <%= link_to "イベント作成", new_event_path, class: "btn btn-primary" %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -20,7 +20,7 @@
 
       <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
         <li><%= link_to "トップ", dashboard_path %></li>
-        <li><%= link_to "イベント作成（仮）", "#" %></li>
+        <li><%= link_to "イベント作成（仮）", new_event_path %></li>
         <li><%= link_to "イベント一覧（仮）", "#" %></li>
         <li>
           <%= link_to "ログアウト",


### PR DESCRIPTION
## 概要
ダッシュボードおよびログイン後ヘッダーから  
イベント作成画面へ遷移できるようにした。

## 実装内容
- ダッシュボードの「イベント作成」ボタンを `new_event_path` に修正
- ログイン後ヘッダーメニュー内の「イベント作成」を実リンクに変更

## 動作確認
- ログイン後、ダッシュボードの「イベント作成」をクリックすると  
  /events/new に遷移すること
- ログイン後ヘッダーの「イベント作成」をクリックすると  
  /events/new に遷移すること
- 遷移先でイベント作成が正常に行えること

Close #41 