### PR TITLE
イベント一覧・詳細画面を追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,12 @@
 class EventsController < ApplicationController
+  def index
+    @events = current_user.events.order(created_at: :desc)
+  end
+
+  def show
+    @event = current_user.events.find(params[:id])
+  end
+
   def new
     @event = Event.new
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -43,7 +43,7 @@
           作成・参加しているイベントを確認できます
         </p>
         <div class="card-actions justify-end">
-          <%= link_to "一覧を見る", "#", class: "btn btn-outline" %>
+          <%= link_to "一覧を見る", events_path, class: "btn btn-outline" %>
         </div>
       </div>
     </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,40 @@
+<div class="max-w-4xl mx-auto p-6">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">イベント一覧</h1>
+    <%= link_to "イベント作成", new_event_path, class: "btn btn-primary btn-sm" %>
+  </div>
+
+  <% if @events.any? %>
+    <div class="space-y-3">
+      <% @events.each do |event| %>
+        <div class="card bg-base-100 shadow-sm">
+          <div class="card-body">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="card-title text-lg">
+                  <%= link_to event.title, event_path(event), class: "link link-hover" %>
+                </h2>
+
+                <p class="text-sm text-gray-600 mt-1">
+                  <%= event.event_date %>
+                  <% if event.event_time.present? %>
+                    <span> / <%= event.event_time.strftime("%H:%M") %></span>
+                  <% end %>
+                  <% if event.place.present? %>
+                    <span> / <%= event.place %></span>
+                  <% end %>
+                </p>
+              </div>
+
+              <%= link_to "詳細", event_path(event), class: "btn btn-outline btn-sm" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="alert">
+      <span>まだイベントがありません。まずはイベントを作成しましょう。</span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,34 @@
+<div class="max-w-4xl mx-auto p-6">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold"><%= @event.title %></h1>
+    <%= link_to "一覧へ戻る", events_path, class: "btn btn-ghost btn-sm" %>
+  </div>
+
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body space-y-3">
+      <div>
+        <p class="text-sm text-gray-500">日時</p>
+        <p class="text-base">
+          <%= @event.event_date %>
+          <% if @event.event_time.present? %>
+            <span> <%= @event.event_time.strftime("%H:%M") %></span>
+          <% end %>
+        </p>
+      </div>
+
+      <div>
+        <p class="text-sm text-gray-500">場所</p>
+        <p class="text-base">
+          <%= @event.place.presence || "未設定" %>
+        </p>
+      </div>
+
+      <div>
+        <p class="text-sm text-gray-500">作成者</p>
+        <p class="text-base"><%= @event.user.name %></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- 本リリースでここに「参加/未参加/作成者」分岐 -->
+</div>

--- a/app/views/shared/_after_login_header.html.erb
+++ b/app/views/shared/_after_login_header.html.erb
@@ -20,8 +20,8 @@
 
       <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
         <li><%= link_to "トップ", dashboard_path %></li>
-        <li><%= link_to "イベント作成（仮）", new_event_path %></li>
-        <li><%= link_to "イベント一覧（仮）", "#" %></li>
+        <li><%= link_to "イベント作成", new_event_path %></li>
+        <li><%= link_to "イベント一覧", events_path %></li>
         <li>
           <%= link_to "ログアウト",
                       logout_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "static_pages#top"
 
-  resources :events, only: %i[new create]
+  resources :events, only: %i[new create index show]
 
   get "dashboard", to: "dashboard#index"
 


### PR DESCRIPTION
## 概要
イベントの一覧・詳細表示を実装。

## 実装内容
- EventsController に index/show を追加
- ルーティングを追加（events の index/show）
- イベント一覧画面（index）を作成（新しい順）
- イベント詳細画面（show）を作成
- 一覧から詳細へ遷移できるリンクを追加

## 動作確認
- ログイン後、イベント一覧が表示されること
- 一覧が新しい順に並ぶこと
- 一覧のリンクから詳細に遷移できること
- 詳細にタイトル/日時/場所などが表示されること

Close #9 