### PR TITLE
イベント編集・削除機能を実装

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,10 +1,11 @@
 class EventsController < ApplicationController
+  before_action :set_event, only: %i[show edit update destroy]
+
   def index
     @events = current_user.events.order(created_at: :desc)
   end
 
   def show
-    @event = current_user.events.find(params[:id])
   end
 
   def new
@@ -22,7 +23,28 @@ class EventsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @event.update(event_params)
+      redirect_to event_path(@event), notice: "イベントを更新しました"
+    else
+      flash.now[:alert] = "入力内容を確認してください"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @event.destroy!
+    redirect_to events_path, notice: "イベントを削除しました"
+  end
+
   private
+
+  def set_event
+    @event = current_user.events.find(params[:id])
+  end
 
   def event_params
     params.require(:event).permit(:title, :event_date, :event_time, :place)

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,56 @@
+<div class="max-w-xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-2">イベント編集</h1>
+  <p class="text-sm text-gray-500 mb-6">
+    内容を修正してイベントを更新します。
+  </p>
+
+  <% if @event.errors.any? %>
+    <div class="alert alert-error mb-6">
+      <div>
+        <p class="font-semibold">入力内容を確認してください</p>
+        <ul class="list-disc ml-5 text-sm mt-2">
+          <% @event.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <%= form_with model: @event do |f| %>
+    <!-- イベント名 -->
+    <div class="form-control mb-4">
+      <%= f.label :title, "イベント名", class: "label" %>
+      <%= f.text_field :title,
+            class: "input input-bordered w-full",
+            placeholder: "金曜ランチ会" %>
+    </div>
+
+    <!-- 開催日 -->
+    <div class="form-control mb-4">
+      <%= f.label :event_date, "開催日", class: "label" %>
+      <%= f.date_field :event_date, class: "input input-bordered w-full" %>
+    </div>
+
+    <!-- 開始時間（任意） -->
+    <div class="form-control mb-4">
+      <%= f.label :event_time, "開始時間（任意）", class: "label" %>
+      <%= f.time_field :event_time, class: "input input-bordered w-full" %>
+    </div>
+
+    <!-- 場所（任意） -->
+    <div class="form-control mb-6">
+      <%= f.label :place, "場所（任意）", class: "label" %>
+      <%= f.text_field :place,
+            class: "input input-bordered w-full",
+            placeholder: "新宿 / 東京駅周辺 など" %>
+    </div>
+
+    <%= f.submit "更新する", class: "btn btn-primary w-full" %>
+
+    <div class="flex gap-2 mt-4">
+      <%= link_to "詳細へ戻る", event_path(@event), class: "btn btn-ghost w-1/2" %>
+      <%= link_to "一覧へ戻る", events_path, class: "btn btn-outline w-1/2" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,17 +1,39 @@
 <div class="max-w-4xl mx-auto p-6">
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold"><%= @event.title %></h1>
-    <%= link_to "一覧へ戻る", events_path, class: "btn btn-ghost btn-sm" %>
+    <div>
+      <h1 class="text-2xl font-bold"><%= @event.title %></h1>
+      <p class="text-sm text-gray-500 mt-1">
+        <%= @event.event_date %>
+        <% if @event.event_time.present? %>
+          <span> <%= @event.event_time.strftime("%H:%M") %></span>
+        <% end %>
+        <% if @event.place.present? %>
+          <span class="mx-2">•</span>
+          <%= @event.place %>
+        <% end %>
+      </p>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <%= link_to "一覧へ戻る", events_path, class: "btn btn-ghost btn-sm" %>
+      <%= link_to "編集", edit_event_path(@event), class: "btn btn-outline btn-sm" %>
+      <%= link_to "削除",
+                  event_path(@event),
+                  data: { turbo_method: :delete, turbo_confirm: "このイベントを削除します。よろしいですか？" },
+                  class: "btn btn-error btn-sm" %>
+    </div>
   </div>
 
   <div class="card bg-base-100 shadow-sm">
-    <div class="card-body space-y-3">
+    <div class="card-body space-y-4">
       <div>
         <p class="text-sm text-gray-500">日時</p>
         <p class="text-base">
           <%= @event.event_date %>
           <% if @event.event_time.present? %>
             <span> <%= @event.event_time.strftime("%H:%M") %></span>
+          <% else %>
+            <span class="text-gray-400">（時間未設定）</span>
           <% end %>
         </p>
       </div>
@@ -30,5 +52,5 @@
     </div>
   </div>
 
-  <!-- 本リリースでここに「参加/未参加/作成者」分岐 -->
+  <!-- MVPでは参加機能なし。将来ここに「参加/未参加/作成者」分岐を追加 -->
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,18 @@
     <%= render "shared/header" %>
 
     <main class="px-4">
+      <% if flash[:notice].present? %>
+        <div class="alert alert-success mb-4">
+          <span><%= flash[:notice] %></span>
+        </div>
+      <% end %>
+
+      <% if flash[:alert].present? %>
+        <div class="alert alert-error mb-4">
+          <span><%= flash[:alert] %></span>
+        </div>
+      <% end %>
+
       <%= yield %>
     </main>
   </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "static_pages#top"
 
-  resources :events, only: %i[new create index show]
+  resources :events, only: %i[index show new create edit update destroy]
 
   get "dashboard", to: "dashboard#index"
 


### PR DESCRIPTION
## 概要

イベントの編集・削除機能を実装。  
作成者のみが自分のイベントを編集・削除できるようにしている。

## 実装内容

- EventsController に edit / update / destroy アクションを追加
- before_action による対象イベントの取得（current_user.events から検索）
- イベント編集フォームの作成（edit.html.erb）
- イベント更新処理（update）
  - 成功時：イベント詳細画面へリダイレクト
  - 失敗時：編集画面に戻してエラーメッセージ表示
- イベント削除処理（destroy）
  - 削除後：イベント一覧画面へリダイレクト
  - 削除時に confirm ダイアログを表示
- イベント詳細画面に編集・削除ボタンを追加
- フラッシュメッセージの設定

## 動作確認

- ログインしてイベント詳細画面へアクセスできること
- 「編集」ボタンから編集画面に遷移できること
-  編集内容を更新できること
- バリデーションエラー時に同画面でエラーが表示されること
- 「削除」ボタンを押すと confirm ダイアログが表示されること
-  削除後にイベント一覧画面へ遷移すること
- 作成者以外のユーザーで /events/:id/edit を直打ちすると RecordNotFound になること

Close  #10