### PR TITLE
MVP最終調整：導線整理・フラッシュ表示・仮実装の削除

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,7 +16,7 @@ class EventsController < ApplicationController
     @event = current_user.events.new(event_params)
 
     if @event.save
-      redirect_to dashboard_path, notice: "イベントを作成しました"
+      redirect_to event_path(@event), notice: "イベントを作成しました"
     else
       flash.now[:alert] = "入力内容を確認してください"
       render :new, status: :unprocessable_entity

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -47,12 +47,5 @@
         </div>
       </div>
     </div>
-
-    <div class="mt-8">
-      <%= link_to "ログアウト（確認用）",
-              logout_path,
-              data: { turbo_method: :delete },
-              class: "btn btn-error btn-sm" %>
-    </div>
   </div>
 </div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -48,9 +48,10 @@
 
     <%= f.submit "更新する", class: "btn btn-primary w-full" %>
 
-    <div class="flex gap-2 mt-4">
-      <%= link_to "詳細へ戻る", event_path(@event), class: "btn btn-ghost w-1/2" %>
-      <%= link_to "一覧へ戻る", events_path, class: "btn btn-outline w-1/2" %>
+    <div class="mt-3 text-center">
+      <%= link_to "詳細へ戻る", event_path(@event), class: "link link-hover text-sm text-gray-500" %>
+      <span class="mx-2 text-gray-300">|</span>
+      <%= link_to "一覧へ戻る", events_path, class: "link link-hover text-sm text-gray-500" %>
     </div>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,14 @@
 <div class="max-w-4xl mx-auto p-6">
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">イベント一覧</h1>
-    <%= link_to "イベント作成", new_event_path, class: "btn btn-primary btn-sm" %>
+
+    <div class="flex items-center gap-3">
+      <%= link_to "戻る", dashboard_path,
+            class: "link link-hover text-sm text-gray-500" %>
+
+      <%= link_to "イベント作成", new_event_path,
+            class: "btn btn-primary btn-sm" %>
+    </div>
   </div>
 
   <% if @events.any? %>
@@ -12,21 +19,27 @@
             <div class="flex items-start justify-between gap-4">
               <div>
                 <h2 class="card-title text-lg">
-                  <%= link_to event.title, event_path(event), class: "link link-hover" %>
+                  <%= link_to event.title,
+                        event_path(event),
+                        class: "link link-hover" %>
                 </h2>
 
                 <p class="text-sm text-gray-600 mt-1">
                   <%= event.event_date %>
+
                   <% if event.event_time.present? %>
                     <span> / <%= event.event_time.strftime("%H:%M") %></span>
                   <% end %>
+
                   <% if event.place.present? %>
                     <span> / <%= event.place %></span>
                   <% end %>
                 </p>
               </div>
 
-              <%= link_to "詳細", event_path(event), class: "btn btn-outline btn-sm" %>
+              <%= link_to "詳細",
+                    event_path(event),
+                    class: "btn btn-outline btn-sm" %>
             </div>
           </div>
         </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,12 +1,15 @@
 <div class="max-w-4xl mx-auto p-6">
-  <div class="flex items-center justify-between mb-6">
+  <!-- ヘッダー（タイトル + サブ情報 + 操作） -->
+  <div class="flex items-start justify-between gap-4 mb-6">
     <div>
-      <h1 class="text-2xl font-bold"><%= @event.title %></h1>
-      <p class="text-sm text-gray-500 mt-1">
+      <h1 class="text-2xl font-bold mb-2"><%= @event.title %></h1>
+
+      <p class="text-sm text-gray-500">
         <%= @event.event_date %>
         <% if @event.event_time.present? %>
           <span> <%= @event.event_time.strftime("%H:%M") %></span>
         <% end %>
+
         <% if @event.place.present? %>
           <span class="mx-2">•</span>
           <%= @event.place %>
@@ -14,9 +17,11 @@
       </p>
     </div>
 
-    <div class="flex items-center gap-2">
-      <%= link_to "一覧へ戻る", events_path, class: "btn btn-ghost btn-sm" %>
+    <div class="flex items-center gap-3">
+      <%= link_to "一覧へ戻る", events_path, class: "link link-hover text-sm text-gray-500" %>
+
       <%= link_to "編集", edit_event_path(@event), class: "btn btn-outline btn-sm" %>
+
       <%= link_to "削除",
                   event_path(@event),
                   data: { turbo_method: :delete, turbo_confirm: "このイベントを削除します。よろしいですか？" },
@@ -24,6 +29,7 @@
     </div>
   </div>
 
+  <!-- 本文カード -->
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body space-y-4">
       <div>


### PR DESCRIPTION
## 概要
MVPリリース前の最終調整として、これまで仮実装していた導線や表示を整理し、
ユーザー体験として不自然な点を整えた。

イベント作成後の遷移先や、各画面間の導線、フラッシュ表示、仮ログアウトボタンの削除などを対応

## 実装内容
- イベント作成後の遷移先をダッシュボードではなくイベント詳細（events#show）に変更
- ダッシュボード / ヘッダーから各画面への導線を整理
  - 「イベント作成」→ `new_event_path`
  - 「イベント一覧」→ `events_path`
  - 「ダッシュボード」→ `dashboard_path`
- イベント詳細画面の表示形式を整理（日時 / 場所 / 作成者など）
- place 未入力時の表示ルールを「未設定」に統一
- フラッシュメッセージ表示を `application.html.erb` に追加（notice / alert）
- new / edit のエラー表示デザインを統一
- ダッシュボードに仮で設置していたログアウトボタンを削除
- ログアウトはログイン後ヘッダー（dropdown）からのみ行えるように整理
- イベント一覧画面に「戻る」導線（dashboard へのリンク）を追加
- 一覧画面と作成画面の導線・トーンを統一

## 動作確認
- 新規登録後、ログイン後トップへ遷移すること
- イベント作成後、イベント詳細画面へ遷移すること
- 一覧 → 詳細 → 編集 → 更新ができること
- 詳細 → 削除 → 一覧へ戻ること（confirm 表示あり）
- 別ユーザーで他人のイベント編集URL直打ち時に弾かれること（RecordNotFound）
- ダッシュボードにログアウトボタンが表示されていないこと
- ログアウトがヘッダーの dropdown からのみ行えること
- フラッシュメッセージが画面上に表示されること
- 一覧画面に戻る導線があり、dashboard に戻れること

Close #45 