### PR TITLE
feat: お店ログにお店メモ機能を追加

### DIFF
--- a/app/controllers/shop_logs_controller.rb
+++ b/app/controllers/shop_logs_controller.rb
@@ -22,6 +22,6 @@ class ShopLogsController < ApplicationController
   private
 
   def shop_params
-    params.require(:shop).permit(:log_category)
+    params.require(:shop).permit(:log_category, :log_note)
   end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -3,6 +3,7 @@ class Shop < ApplicationRecord
   belongs_to :user
 
   validates :name, presence: true
+  validates :log_note, length: { maximum: 1000, message: "は1000文字以内で入力してください" }
 
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user

--- a/app/views/shop_logs/edit.html.erb
+++ b/app/views/shop_logs/edit.html.erb
@@ -1,17 +1,37 @@
 <div class="max-w-xl mx-auto p-6">
 
-  <h1 class="text-xl font-bold mb-4">カテゴリを編集</h1>
+  <h1 class="text-xl font-bold mb-4">お店ログを編集</h1>
 
   <div class="card bg-base-100 shadow">
     <div class="card-body">
 
+      <!-- エラーメッセージ -->
+      <% if @shop.errors.any? %>
+        <div class="mb-4 rounded-lg bg-error/10 p-4 text-sm text-error">
+          <p class="font-semibold mb-2">保存できませんでした</p>
+          <ul class="list-disc pl-5 space-y-1">
+            <% @shop.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
       <%= form_with model: @shop, url: shop_log_path(@shop), method: :patch, local: true do |f| %>
-        
+
+        <!-- カテゴリ -->
         <div class="form-control">
           <%= f.label :log_category, "カテゴリ", class: "label" %>
           <%= f.text_field :log_category, class: "input input-bordered w-full" %>
         </div>
 
+        <!-- メモ -->
+        <div class="form-control mt-4">
+          <%= f.label :log_note, "お店メモ", class: "label" %>
+          <%= f.text_area :log_note, rows: 5, class: "textarea textarea-bordered w-full" %>
+        </div>
+
+        <!-- ボタン -->
         <div class="mt-4 flex justify-end gap-2">
           <%= link_to "戻る", shop_logs_path, class: "btn btn-ghost" %>
           <%= f.submit "保存する", class: "btn btn-primary" %>

--- a/app/views/shop_logs/index.html.erb
+++ b/app/views/shop_logs/index.html.erb
@@ -15,44 +15,70 @@
       <% if @shops.any? %>
         <ul class="space-y-4">
           <% @shops.each do |shop| %>
-            <li class="border border-base-300 rounded-lg p-4 space-y-2">
+            <li class="border border-base-300 rounded-lg p-4">
+              <div class="grid gap-4 md:grid-cols-2 items-stretch">
 
-              <p class="font-semibold text-lg"><%= shop.name %></p>
+                <!-- 左：お店情報 -->
+                <div class="space-y-2">
 
-              <% if shop.log_category.present? %>
-                <div class="mt-1">
-                  <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-medium <%= category_color(shop.log_category) %>">
-                    <%= shop.log_category %>
-                  </span>
+                  <p class="font-semibold text-lg"><%= shop.name %></p>
+
+                  <% if shop.log_category.present? %>
+                    <div class="mt-1">
+                      <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-medium <%= category_color(shop.log_category) %>">
+                        <%= shop.log_category %>
+                      </span>
+                    </div>
+                  <% end %>
+
+                  <% if shop.url.present? %>
+                    <p class="text-sm">
+                      <a href="<%= shop.url %>" target="_blank" class="link link-primary">
+                        お店のページを見る
+                      </a>
+                    </p>
+                  <% end %>
+
+                  <% if shop.memo.present? %>
+                    <p class="text-sm text-gray-600"><%= shop.memo %></p>
+                  <% end %>
+
+                  <p class="text-sm text-gray-500">
+                    イベント：<%= shop.event.title %>
+                  </p>
+
+                  <p class="text-xs text-gray-400">
+                    登録日：<%= shop.created_at.strftime("%Y-%m-%d") %>
+                  </p>
+
+                  <div class="mt-2">
+                    <%= link_to "編集",
+                      edit_shop_log_path(shop),
+                      class: "btn btn-outline btn-sm" %>
+                  </div>
+
                 </div>
-              <% end %>
 
-              <% if shop.url.present? %>
-                <p class="text-sm">
-                  <a href="<%= shop.url %>" target="_blank" class="link link-primary">
-                    お店のページを見る
-                  </a>
-                </p>
-              <% end %>
+                <!-- 右：お店メモ -->
+                <div class="w-full md:w-auto">
+                  <% if shop.log_note.present? %>
+                    <div class="bg-amber-50 border border-amber-100 rounded-lg p-4 shadow-sm h-full flex flex-col w-full">
+                      <p class="text-xs text-gray-500 mb-2">📌 お店メモ</p>
 
-              <% if shop.memo.present? %>
-                <p class="text-sm text-gray-600"><%= shop.memo %></p>
-              <% end %>
+                      <p class="text-xs md:text-sm text-left leading-relaxed whitespace-pre-line break-words">
+                        <%= shop.log_note %>
+                      </p>
+                    </div>
+                  <% else %>
+                    <div class="border border-dashed border-base-300 rounded-lg p-4 h-full flex items-center justify-center w-full">
+                      <p class="text-xs text-gray-400 text-center">
+                        お店メモはまだありません
+                      </p>
+                    </div>
+                  <% end %>
+                </div>
 
-              <p class="text-sm text-gray-500">
-                イベント：<%= shop.event.title %>
-              </p>
-
-              <p class="text-xs text-gray-400">
-                登録日：<%= shop.created_at.strftime("%Y-%m-%d") %>
-              </p>
-
-              <div class="mt-2">
-                <%= link_to "カテゴリ編集",
-                  edit_shop_log_path(shop),
-                  class: "btn btn-outline btn-sm" %>
               </div>
-
             </li>
           <% end %>
         </ul>

--- a/db/migrate/20260401151906_add_log_note_to_shops.rb
+++ b/db/migrate/20260401151906_add_log_note_to_shops.rb
@@ -1,0 +1,5 @@
+class AddLogNoteToShops < ActiveRecord::Migration[7.1]
+  def change
+    add_column :shops, :log_note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_31_060820) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_01_151906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_31_060820) do
     t.integer "likes_count", default: 0, null: false
     t.string "place_id"
     t.string "log_category"
+    t.text "log_note"
     t.index ["event_id"], name: "index_shops_on_event_id"
     t.index ["user_id"], name: "index_shops_on_user_id"
   end


### PR DESCRIPTION
## 概要
お店ログに「お店メモ」機能を追加した。

## 実装内容
- shopsテーブルにlog_noteカラムを追加
- お店ログ編集画面にお店メモ入力欄を追加
- 一覧画面にお店メモ表示を追加
- メモ未入力時のプレースホルダー表示を追加
- 文字数制限（1000文字）を追加
- バリデーションエラー表示を追加

## UI
- PCでは2カラムレイアウトで表示
- スマホではメモを横幅いっぱいに表示
- 付箋風デザインで視認性を向上

## 確認内容
- メモが保存・更新されること
- 1000文字超でバリデーションが効くこと
- エラーメッセージが表示されること
- スマホ・PCでレイアウトが崩れないこと

## 補足
- メモは任意入力
- お店ごとの記録として使用する想定

Close #61 