### PR TITLE
feat: お店ログに並び替え・絞り込み機能を追加

### DIFF
--- a/app/controllers/shop_logs_controller.rb
+++ b/app/controllers/shop_logs_controller.rb
@@ -1,8 +1,26 @@
 class ShopLogsController < ApplicationController
   def index
-    @shops = current_user.shops
-                         .includes(:event)
-                         .order(created_at: :desc)
+    @shops = current_user.shops.includes(:event)
+
+    # カテゴリ絞り込み
+    if params[:category].present?
+      @shops = @shops.where(log_category: params[:category])
+    end
+
+    # 並び替え
+    @shops =
+      case params[:sort]
+      when "old"
+        @shops.order(created_at: :asc)
+      else
+        @shops.order(created_at: :desc)
+      end
+
+    # カテゴリ一覧（セレクト用）
+    @categories = current_user.shops
+                              .where.not(log_category: [nil, ""])
+                              .distinct
+                              .pluck(:log_category)
   end
 
   def edit
@@ -13,7 +31,7 @@ class ShopLogsController < ApplicationController
     @shop = current_user.shops.find(params[:id])
 
     if @shop.update(shop_params)
-      redirect_to shop_logs_path, notice: "カテゴリを更新しました"
+      redirect_to shop_logs_path, notice: "お店ログを更新しました"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/shop_logs/index.html.erb
+++ b/app/views/shop_logs/index.html.erb
@@ -7,7 +7,45 @@
       これまでに登録したお店をまとめて見返せます📖
     </p>
   </div>
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body">
+      <%= form_with url: shop_logs_path, method: :get, local: true, class: "flex flex-col gap-4 md:flex-row md:items-end" do %>
 
+        <div class="form-control w-full md:w-52">
+          <label class="label">
+            <span class="label-text">並び替え</span>
+          </label>
+          <%= select_tag :sort,
+            options_for_select(
+              [
+                ["新しい順", "recent"],
+                ["古い順", "old"]
+              ],
+              params[:sort]
+            ),
+            class: "select select-bordered w-full" %>
+        </div>
+
+        <div class="form-control w-full md:w-52">
+          <label class="label">
+            <span class="label-text">カテゴリ</span>
+          </label>
+          <%= select_tag :category,
+            options_for_select(
+              [["すべて", ""]] + @categories.map { |category| [category, category] },
+              params[:category]
+            ),
+            class: "select select-bordered w-full" %>
+        </div>
+
+        <div class="flex gap-2">
+          <%= submit_tag "適用", class: "btn btn-primary" %>
+          <%= link_to "リセット", shop_logs_path, class: "btn btn-ghost" %>
+        </div>
+
+      <% end %>
+    </div>
+  </div>
   <!-- 一覧 -->
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body">


### PR DESCRIPTION
## 概要
お店ログ一覧に並び替えとカテゴリ絞り込み機能を追加

## 実装内容
- params（sort / category）を使った条件分岐を追加
- 並び替え（新しい順・古い順）を実装
- カテゴリ絞り込みを実装
- カテゴリ一覧を取得してセレクトに表示
- 一覧上部にUI（select + ボタン）を追加
- 選択状態が保持されるように対応
- リセットボタンを追加

## 確認内容
- 並び替えが正しく動くこと
- カテゴリで絞り込めること
- 両方同時に適用できること
- 選択状態が保持されること
- リセットで初期状態に戻ること

## 補足
- UIの細かい調整は検索機能追加時にまとめて対応予定

Close #62