### PR TITLE
feat: お店ログ検索機能とオートコンプリートを実装

### DIFF
--- a/app/controllers/shop_logs_controller.rb
+++ b/app/controllers/shop_logs_controller.rb
@@ -2,6 +2,11 @@ class ShopLogsController < ApplicationController
   def index
     @shops = current_user.shops.includes(:event)
 
+    # 検索
+    if params[:q].present?
+      @shops = @shops.where("name LIKE ?", "%#{params[:q]}%")
+    end
+
     # カテゴリ絞り込み
     if params[:category].present?
       @shops = @shops.where(log_category: params[:category])
@@ -21,6 +26,19 @@ class ShopLogsController < ApplicationController
                               .where.not(log_category: [nil, ""])
                               .distinct
                               .pluck(:log_category)
+  end
+
+  # オートコンプリート
+  def autocomplete
+    shops = current_user.shops
+
+    if params[:q].present?
+      shops = shops.where("name LIKE ?", "%#{params[:q]}%").limit(5)
+    else
+      shops = []
+    end
+
+    render json: shops.pluck(:name)
   end
 
   def edit

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "results"]
+
+  connect() {
+    console.log("autocomplete controller connected")
+  }
+
+  search() {
+    const query = this.inputTarget.value
+    console.log("動いたよ", query)
+
+    if (query.length === 0) {
+      this.resultsTarget.innerHTML = ""
+      this.resultsTarget.classList.add("hidden")
+      return
+    }
+
+    fetch(`/shop_logs/autocomplete?q=${encodeURIComponent(query)}`)
+      .then(response => response.json())
+      .then(data => {
+        console.log("autocomplete data:", data)
+
+        this.resultsTarget.innerHTML = ""
+
+        data.forEach((name) => {
+          const item = document.createElement("div")
+          item.textContent = name
+          item.className = "p-2 hover:bg-gray-100 cursor-pointer"
+
+          item.addEventListener("click", () => {
+            this.inputTarget.value = name
+            this.resultsTarget.innerHTML = ""
+            this.resultsTarget.classList.add("hidden")
+          })
+
+          this.resultsTarget.appendChild(item)
+        })
+
+        if (data.length > 0) {
+          this.resultsTarget.classList.remove("hidden")
+        } else {
+          this.resultsTarget.classList.add("hidden")
+        }
+      })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("clipboard", ClipboardController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import AutocompleteController from "./autocomplete_controller"
+application.register("autocomplete", AutocompleteController)

--- a/app/views/shop_logs/index.html.erb
+++ b/app/views/shop_logs/index.html.erb
@@ -7,40 +7,72 @@
       これまでに登録したお店をまとめて見返せます📖
     </p>
   </div>
+  
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body">
-      <%= form_with url: shop_logs_path, method: :get, local: true, class: "flex flex-col gap-4 md:flex-row md:items-end" do %>
+      <%= form_with url: shop_logs_path, method: :get, local: true,
+        class: "flex flex-col gap-4 md:flex-row md:items-end md:justify-between" do %>
 
-        <div class="form-control w-full md:w-52">
+        <!-- 左：検索 -->
+        <div class="form-control w-full md:w-1/3"
+             data-controller="autocomplete">
+
           <label class="label">
-            <span class="label-text">並び替え</span>
+            <span class="label-text">検索</span>
           </label>
-          <%= select_tag :sort,
-            options_for_select(
-              [
-                ["新しい順", "recent"],
-                ["古い順", "old"]
-              ],
-              params[:sort]
-            ),
-            class: "select select-bordered w-full" %>
+
+          <%= text_field_tag :q, params[:q],
+            placeholder: "店名で検索",
+            class: "input input-bordered w-full",
+            data: {
+              autocomplete_target: "input",
+              action: "input->autocomplete#search"
+            } %>
+
+           <div id="autocomplete-results"
+                data-autocomplete-target="results"
+                class="bg-white border border-gray-200 rounded mt-1 hidden"></div>
+
         </div>
 
-        <div class="form-control w-full md:w-52">
-          <label class="label">
-            <span class="label-text">カテゴリ</span>
-          </label>
-          <%= select_tag :category,
-            options_for_select(
-              [["すべて", ""]] + @categories.map { |category| [category, category] },
-              params[:category]
-            ),
-            class: "select select-bordered w-full" %>
-        </div>
+        <!-- 右：フィルター -->
+        <div class="flex flex-col gap-4 md:flex-row md:items-end">
 
-        <div class="flex gap-2">
-          <%= submit_tag "適用", class: "btn btn-primary" %>
-          <%= link_to "リセット", shop_logs_path, class: "btn btn-ghost" %>
+          <!-- 並び替え -->
+          <div class="form-control w-full md:w-40">
+            <label class="label">
+              <span class="label-text">並び替え</span>
+            </label>
+            <%= select_tag :sort,
+              options_for_select(
+                [
+                  ["新しい順", "recent"],
+                  ["古い順", "old"]
+                ],
+                params[:sort]
+              ),
+              class: "select select-bordered w-full" %>
+          </div>
+
+          <!-- カテゴリ -->
+          <div class="form-control w-full md:w-40">
+            <label class="label">
+              <span class="label-text">カテゴリ</span>
+            </label>
+            <%= select_tag :category,
+              options_for_select(
+                [["すべて", ""]] + @categories.map { |c| [c, c] },
+                params[:category]
+              ),
+              class: "select select-bordered w-full" %>
+          </div>
+
+          <!-- ボタン -->
+          <div class="flex gap-2">
+            <%= submit_tag "検索", class: "btn btn-primary" %>
+            <%= link_to "リセット", shop_logs_path, class: "btn btn-ghost" %>
+          </div>
+
         </div>
 
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   end
   
   resources :shop_logs, only: [:index, :edit, :update]
+  
+  get "shop_logs/autocomplete", to: "shop_logs#autocomplete"
 
   get "/events/join/:unique_url", to: "events#join", as: "join_event"
   


### PR DESCRIPTION
## 概要
お店ログ一覧に対する検索機能と、入力補助のための簡易オートコンプリート機能を実装した。

## 実装内容
- お店ログ一覧に検索フォームを設置
- params[:q] を用いた店名の部分一致検索を実装
- 検索条件を保持できるように対応
- /shop_logs/autocomplete を追加
- ShopLogsController#autocomplete を実装
- current_user.shops を対象に候補取得するよう対応
- 入力値がある場合のみ候補検索を行うよう実装
- 候補を最大5件返すように実装
- autocomplete_controller.js を作成
- 入力時に候補取得を行う処理を実装
- 候補リストの表示処理を追加
- 候補クリックで検索フォームに値を反映する処理を追加
- autocomplete コントローラーを Stimulus に登録

## 動作確認
- 店名で部分一致検索できる
- 自分が登録したお店のみ検索対象になる
- 検索条件が保持される
- 入力に応じて候補が表示される
- 候補クリックで入力欄に反映される
- 該当なしの場合でもUIが崩れない
- 空入力時に候補が表示されない

## 補足
- 本リリースでは、オートコンプリートは簡易実装としている
- 現時点では候補表示と選択機能を優先している
- 今後余裕があれば debounce、表記ゆれ対応、キーボード操作対応などを検討する

Closes #69