### PR TITLE
feat: Rubocopを導入しコードスタイルを統一

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+# Omakase Ruby styling for Rails
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+
+# バージョン指定とgemおすすめ通知不要
+AllCops:
+  TargetRubyVersion: 3.3
+  SuggestExtensions: false
+
+# ダブルクオーテーションを使う
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 ruby "3.3.10"
@@ -31,8 +33,8 @@ gem "jbuilder"
 
 gem "devise"
 
-gem "rails-i18n"
 gem "devise-i18n"
+gem "rails-i18n"
 
 gem "omniauth-line-v2"
 gem "omniauth-rails_csrf_protection"
@@ -47,7 +49,7 @@ gem "omniauth-rails_csrf_protection"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[windows jruby]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -57,7 +59,11 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ]
+  gem "debug", platforms: %i[mri windows]
+
+  gem "rubocop", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rails-omakase", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.21)
     benchmark (0.5.0)
@@ -148,6 +149,7 @@ GEM
     json (2.19.2)
     jwt (3.1.2)
       base64
+    language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -159,6 +161,7 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
+    lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.0)
       crass (~> 1.0.2)
@@ -229,6 +232,10 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
+    parallel (1.28.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
@@ -293,6 +300,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.1)
     rdoc (7.0.3)
       erb
@@ -305,6 +313,35 @@ GEM
       actionpack (>= 7.0)
       railties (>= 7.0)
     rexml (3.4.4)
+    rubocop (1.86.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.34.3)
+      activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
+      rack (>= 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rails-omakase (1.1.0)
+      rubocop (>= 1.72)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.30)
+    ruby-progressbar (1.13.0)
     rubyzip (3.2.2)
     securerandom (0.4.1)
     selenium-webdriver (4.39.0)
@@ -335,6 +372,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     version_gem (1.1.9)
     warden (1.2.9)
@@ -380,6 +420,9 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.6)
   rails-i18n
+  rubocop
+  rubocop-rails
+  rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails
   stimulus-rails
@@ -400,6 +443,7 @@ CHECKSUMS
   activestorage (7.1.6) sha256=2f1acb8e6592ba783d9cbc3da93ac4477d441dffc5d533ceccbbfab39f4bf398
   activesupport (7.1.6) sha256=7f12140a813b1c4922a322663e547129aef1840fc512fa262378f6d7e7fd3a7c
   addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.21) sha256=5964613d750a42c7ee5dc61f7b9336fb6caca429ba4ac9f2011609946e4a2dcf
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
@@ -432,9 +476,11 @@ CHECKSUMS
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
   json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
   letter_opener_web (3.0.0) sha256=3f391efe0e8b9b24becfab5537dfb17a5cf5eb532038f947daab58cb4b749860
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
@@ -465,6 +511,8 @@ CHECKSUMS
   omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
   omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
   pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
   pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
@@ -489,12 +537,19 @@ CHECKSUMS
   rails-html-sanitizer (1.6.2) sha256=35fce2ca8242da8775c83b6ba9c1bcaad6751d9eb73c1abaa8403475ab89a560
   rails-i18n (7.0.10) sha256=efae16e0ac28c0f42e98555c8db1327d69ab02058c8b535e0933cb106dd931ca
   railties (7.1.6) sha256=2a10e97f2eaca66d11f0fef4b1f4d826e6ee28d4cf01ff16624420dd45e7de1c
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.0.3) sha256=dfe3d0981d19b7bba71d9dbaeb57c9f4e3a7a4103162148a559c4fc687ea81f9
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.86.0) sha256=4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rails (2.34.3) sha256=10d37989024865ecda8199f311f3faca990143fbac967de943f88aca11eb9ad2
+  rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.39.0) sha256=984a1e63d39472eaf286bac3c6f1822fa7eea6eed9c07a66ce7b3bc5417ba826
@@ -508,6 +563,8 @@ CHECKSUMS
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo-rails (2.0.20) sha256=cbcbb4dd3ce59f6471c9f911b1655b2c721998cc8303959d982da347f374ea95
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 
   # ログイン後の遷移先

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 class DashboardController < ApplicationController
   before_action :authenticate_user!
-  def index
-  end
+  def index; end
 end

--- a/app/controllers/event_participants_controller.rb
+++ b/app/controllers/event_participants_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventParticipantsController < ApplicationController
   before_action :authenticate_user!
 

--- a/app/controllers/event_preferences_controller.rb
+++ b/app/controllers/event_preferences_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventPreferencesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_event
@@ -5,7 +7,7 @@ class EventPreferencesController < ApplicationController
 
   def create
     @event_preference = @event.event_preferences.find_or_initialize_by(user: current_user)
-    
+
     if @event_preference.update(event_preference_params)
       redirect_to event_path(@event), notice: "希望の条件を保存しました"
     else
@@ -15,7 +17,7 @@ class EventPreferencesController < ApplicationController
 
   def destroy
     @event_preference = @event.event_preferences.find_by(user: current_user)
-    @event_preference.destroy if @event_preference
+    @event_preference&.destroy
     redirect_to event_path(@event), notice: "希望条件を削除しました"
   end
 
@@ -26,9 +28,9 @@ class EventPreferencesController < ApplicationController
   end
 
   def ensure_event_participant
-    unless @event.participants.exists?(current_user.id)
-      redirect_to event_path(@event), alert: "イベント参加者のみ希望条件を入力できます"
-    end
+    return if @event.participants.exists?(current_user.id)
+
+    redirect_to event_path(@event), alert: "イベント参加者のみ希望条件を入力できます"
   end
 
   def event_preference_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventsController < ApplicationController
   before_action :authenticate_user!, except: %i[join]
   before_action :set_event, only: %i[show]
@@ -10,17 +12,17 @@ class EventsController < ApplicationController
   def show
     @participating = user_signed_in? && @event.event_participants.exists?(user_id: current_user.id)
     @participants = @event.participants
-    # 並び替え用　
+    # 並び替え用
     @shops =
-    case params[:sort]
-    when "likes_count"
-      @event.shops.includes(:user, :likes).order(likes_count: :desc, created_at: :asc)
-    else
-      @event.shops.includes(:user, :likes).order(created_at: :asc)
-    end
+      case params[:sort]
+      when "likes_count"
+        @event.shops.includes(:user, :likes).order(likes_count: :desc, created_at: :asc)
+      else
+        @event.shops.includes(:user, :likes).order(created_at: :asc)
+      end
     # ランキング用
     @top_shops = @event.shops.order(likes_count: :desc, created_at: :asc).limit(3)
-    
+
     # 希望条件フォーム用
     @event_preference =
       if user_signed_in?
@@ -54,6 +56,8 @@ class EventsController < ApplicationController
     @event = Event.new
   end
 
+  def edit; end
+
   def create
     @event = current_user.events.new(event_params)
 
@@ -61,18 +65,15 @@ class EventsController < ApplicationController
       @event.event_participants.create(user: current_user)
       redirect_to event_path(@event), notice: "イベントを作成しました"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
-  end
-
-  def edit
   end
 
   def update
     if @event.update(event_params)
       redirect_to event_path(@event), notice: "イベントを更新しました"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LikesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_event
@@ -25,8 +27,8 @@ class LikesController < ApplicationController
   end
 
   def ensure_event_participant
-    unless @event.participants.exists?(current_user.id)
-      redirect_to event_path(@event), alert: "イベント参加者のみいいねできます"
-    end
+    return if @event.participants.exists?(current_user.id)
+
+    redirect_to event_path(@event), alert: "イベント参加者のみいいねできます"
   end
 end

--- a/app/controllers/shop_logs_controller.rb
+++ b/app/controllers/shop_logs_controller.rb
@@ -1,16 +1,14 @@
+# frozen_string_literal: true
+
 class ShopLogsController < ApplicationController
   def index
     @shops = current_user.shops.includes(:event)
 
     # 検索
-    if params[:q].present?
-      @shops = @shops.where("name LIKE ?", "%#{params[:q]}%")
-    end
+    @shops = @shops.where("name LIKE ?", "%#{params[:q]}%") if params[:q].present?
 
     # カテゴリ絞り込み
-    if params[:category].present?
-      @shops = @shops.where(log_category: params[:category])
-    end
+    @shops = @shops.where(log_category: params[:category]) if params[:category].present?
 
     # 並び替え
     @shops =
@@ -23,7 +21,7 @@ class ShopLogsController < ApplicationController
 
     # カテゴリ一覧（セレクト用）
     @categories = current_user.shops
-                              .where.not(log_category: [nil, ""])
+                              .where.not(log_category: [ nil, "" ])
                               .distinct
                               .pluck(:log_category)
   end
@@ -32,10 +30,10 @@ class ShopLogsController < ApplicationController
   def autocomplete
     shops = current_user.shops
 
-    if params[:q].present?
-      shops = shops.where("name LIKE ?", "%#{params[:q]}%").limit(5)
+    shops = if params[:q].present?
+              shops.where("name LIKE ?", "%#{params[:q]}%").limit(5)
     else
-      shops = []
+              []
     end
 
     render json: shops.pluck(:name)
@@ -51,7 +49,7 @@ class ShopLogsController < ApplicationController
     if @shop.update(shop_params)
       redirect_to shop_logs_path, notice: "お店ログを更新しました"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShopsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_event
@@ -9,20 +11,19 @@ class ShopsController < ApplicationController
     @shop = @event.shops.new
   end
 
+  def edit; end
+
   def create
     @shop = @event.shops.new(shop_params)
     @shop.user = current_user
-  
+
     @shop.place_id = @shop.fetch_place_id(@event.place)
 
     if @shop.save
       redirect_to event_path(@event), notice: "お店候補を登録しました"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
-  end
-
-  def edit
   end
 
   def update
@@ -38,7 +39,7 @@ class ShopsController < ApplicationController
     if @shop.save
       redirect_to event_path(@event), notice: "お店候補を更新しました"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -54,9 +55,9 @@ class ShopsController < ApplicationController
   end
 
   def ensure_event_participant
-    unless @event.participants.exists?(current_user.id)
-      redirect_to event_path(@event), alert: "イベント参加者のみお店候補を操作できます"
-    end
+    return if @event.participants.exists?(current_user.id)
+
+    redirect_to event_path(@event), alert: "イベント参加者のみお店候補を操作できます"
   end
 
   def set_shop
@@ -64,9 +65,9 @@ class ShopsController < ApplicationController
   end
 
   def ensure_shop_owner
-    unless @shop.user == current_user
-      redirect_to event_path(@event), alert: "お店候補の編集・削除は登録者のみ可能です"
-    end
+    return if @shop.user == current_user
+
+    redirect_to event_path(@event), alert: "お店候補の編集・削除は登録者のみ可能です"
   end
 
   def shop_params

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StaticPagesController < ApplicationController
   def top; end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,31 +1,35 @@
-class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  def line
-    auth = request.env["omniauth.auth"]
+# frozen_string_literal: true
 
-    @user = User.find_or_initialize_by(provider: auth.provider, uid: auth.uid)
+module Users
+  class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    def line
+      auth = request.env["omniauth.auth"]
 
-    if @user.new_record?
-      @user.email = dummy_email(auth)
-      @user.name = auth.info.name.presence || "LINEユーザー"
-      @user.password = Devise.friendly_token[0, 20]
-      @user.save
+      @user = User.find_or_initialize_by(provider: auth.provider, uid: auth.uid)
+
+      if @user.new_record?
+        @user.email = dummy_email(auth)
+        @user.name = auth.info.name.presence || "LINEユーザー"
+        @user.password = Devise.friendly_token[0, 20]
+        @user.save
+      end
+
+      if @user.persisted?
+        sign_in @user
+        redirect_to dashboard_path, notice: "LINEでログインしました"
+      else
+        redirect_to new_user_session_path, alert: "LINEログインに失敗しました"
+      end
     end
 
-    if @user.persisted?
-      sign_in @user
-      redirect_to dashboard_path, notice: "LINEでログインしました"
-    else
+    def failure
       redirect_to new_user_session_path, alert: "LINEログインに失敗しました"
     end
-  end
 
-  def failure
-    redirect_to new_user_session_path, alert: "LINEログインに失敗しました"
-  end
+    private
 
-  private
-
-  def dummy_email(auth)
-    "#{auth.uid}-line@example.com"
+    def dummy_email(auth)
+      "#{auth.uid}-line@example.com"
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module DashboardHelper
 end

--- a/app/helpers/event_participants_helper.rb
+++ b/app/helpers/event_participants_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module EventParticipantsHelper
 end

--- a/app/helpers/event_preferences_helper.rb
+++ b/app/helpers/event_preferences_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module EventPreferencesHelper
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module EventsHelper
 end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module LikesHelper
 end

--- a/app/helpers/shop_logs_helper.rb
+++ b/app/helpers/shop_logs_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ShopLogsHelper
   CATEGORY_COLORS = [
     "bg-blue-100 text-blue-700",

--- a/app/helpers/shops_helper.rb
+++ b/app/helpers/shops_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ShopsHelper
 end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module StaticPagesHelper
 end

--- a/app/helpers/user_sessions_helper.rb
+++ b/app/helpers/user_sessions_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module UserSessionsHelper
 end

--- a/app/helpers/users/omniauth_callbacks_helper.rb
+++ b/app/helpers/users/omniauth_callbacks_helper.rb
@@ -1,2 +1,6 @@
-module Users::OmniauthCallbacksHelper
+# frozen_string_literal: true
+
+module Users
+  module OmniauthCallbacksHelper
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module UsersHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,15 +1,16 @@
+# frozen_string_literal: true
+
 class Event < ApplicationRecord
   belongs_to :user
   has_many :event_participants, dependent: :destroy
   has_many :participants, through: :event_participants, source: :user
   has_many :shops, dependent: :destroy
   has_many :event_preferences, dependent: :destroy
-  
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :event_date, presence: true
   validates :unique_url, presence: true, uniqueness: true, length: { maximum: 255 }
   validates :note, length: { maximum: 1000 }, allow_blank: true
-  
 
   before_validation :set_unique_url, on: :create
 

--- a/app/models/event_participant.rb
+++ b/app/models/event_participant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventParticipant < ApplicationRecord
   belongs_to :event
   belongs_to :user

--- a/app/models/event_preference.rb
+++ b/app/models/event_preference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventPreference < ApplicationRecord
   belongs_to :event
   belongs_to :user

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Like < ApplicationRecord
   belongs_to :shop, counter_cache: true
   belongs_to :user

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Shop < ApplicationRecord
   belongs_to :event
   belongs_to :user
@@ -10,13 +12,13 @@ class Shop < ApplicationRecord
 
   # 地図検索用の文字列を作る（店名 + イベント場所）
   def map_query(event_place = nil)
-    [name, event_place].compact.join(" ")
+    [ name, event_place ].compact.join(" ")
   end
 
   # Google Map埋め込み用URL（place_idがあれば優先して使用、なければ店名ベースでフォールバック）
   def map_embed_url(event_place = nil)
     if place_id.present?
-      "https://www.google.com/maps/embed/v1/place?key=#{ENV['GOOGLE_MAPS_API_KEY']}&q=place_id:#{place_id}"
+      "https://www.google.com/maps/embed/v1/place?key=#{ENV.fetch('GOOGLE_MAPS_API_KEY', nil)}&q=place_id:#{place_id}"
     else
       "https://www.google.com/maps?q=#{CGI.escape(map_query(event_place))}&output=embed"
     end
@@ -35,7 +37,7 @@ class Shop < ApplicationRecord
       "https://places.googleapis.com/v1/places:searchText"
     ) do |req|
       req.headers["Content-Type"] = "application/json"
-      req.headers["X-Goog-Api-Key"] = ENV["GOOGLE_MAPS_API_KEY"]
+      req.headers["X-Goog-Api-Key"] = ENV.fetch("GOOGLE_MAPS_API_KEY", nil)
       req.headers["X-Goog-FieldMask"] = "places.id"
       req.body = { textQuery: query }.to_json
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [:line]
+         :omniauthable, omniauth_providers: [ :line ]
 
   validates :name, presence: true, length: { maximum: 255 }
-  
+
   has_many :events, dependent: :destroy
   has_many :event_participants, dependent: :destroy
   has_many :participating_events, through: :event_participants, source: :event

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative "config/environment"

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails/all"
@@ -16,7 +18,7 @@ module Myapp
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
+    config.autoload_lib(ignore: %w[assets tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative "application"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
@@ -52,9 +54,9 @@ Rails.application.configure do
   config.force_ssl = true
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  config.logger = ActiveSupport::Logger.new($stdout)
+                                       .tap { |logger| logger.formatter = Logger::Formatter.new }
+                                       .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -37,7 +37,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -59,12 +59,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [ :email ]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [ :email ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -98,7 +98,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [ :http_auth ]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX
@@ -276,10 +276,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  
+
   config.omniauth :line,
-    ENV['LINE_CHANNEL_ID'],
-    ENV['LINE_CHANNEL_SECRET']
+                  ENV.fetch("LINE_CHANNEL_ID", nil),
+                  ENV.fetch("LINE_CHANNEL_SECRET", nil)
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
@@ -317,7 +317,7 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-  
- # パスワード再設定時などに「存在しないメール」を判別できないようにする（ユーザー列挙対策）
-  config.paranoid = true 
+
+  # パスワード再設定時などに「存在しないメール」を判別できないようにする（ユーザー列挙対策）
+  config.paranoid = true
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
 ]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide HTTP permissions policy. For further

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
@@ -7,11 +9,11 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-rails_env = ENV.fetch("RAILS_ENV") { "development" }
+rails_env = ENV.fetch("RAILS_ENV", "development")
 
 if rails_env == "production"
   # If you are running more than 1 thread per process, the workers count
@@ -20,7 +22,7 @@ if rails_env == "production"
   # It defaults to 1 because it's impossible to reliably detect how many
   # CPU cores are available. Make sure to set the `WEB_CONCURRENCY` environment
   # variable to match the number of processors.
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { 1 })
+  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY", 1))
   if worker_count > 1
     workers worker_count
   else
@@ -32,13 +34,13 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 environment rails_env
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,33 +1,33 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks"
   }
   root "static_pages#top"
-  
+
   get "terms",   to: "static_pages#terms"
   get "privacy", to: "static_pages#privacy"
 
   resources :events, only: %i[index show new create edit update destroy] do
-    resources :event_participants, only: [:create]
-    
-    resources :event_preferences, only: [:create, :destroy]
-    
+    resources :event_participants, only: [ :create ]
+
+    resources :event_preferences, only: %i[create destroy]
+
     resources :shops, only: %i[new create edit update destroy] do
       resource :like, only: %i[create destroy]
     end
   end
-  
-  resources :shop_logs, only: [:index, :edit, :update]
-  
+
+  resources :shop_logs, only: %i[index edit update]
+
   get "shop_logs/autocomplete", to: "shop_logs#autocomplete"
 
   get "/events/join/:unique_url", to: "events#join", as: "join_event"
-  
+
   get "dashboard", to: "dashboard#index"
 
   # 開発環境だけ、送信メール確認ページを有効化
-  if Rails.env.development?
-    mount LetterOpenerWeb::Engine, at: "/letter_opener"
-  end
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/db/migrate/20260114161004_sorcery_core.rb
+++ b/db/migrate/20260114161004_sorcery_core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SorceryCore < ActiveRecord::Migration[7.1]
   def change
     create_table :users do |t|
@@ -5,7 +7,7 @@ class SorceryCore < ActiveRecord::Migration[7.1]
       t.string :email, null: false, index: { unique: true }
       t.string :crypted_password
       t.string :salt
-      t.timestamps                null: false
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20260120142514_create_events.rb
+++ b/db/migrate/20260120142514_create_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateEvents < ActiveRecord::Migration[7.1]
   def change
     create_table :events do |t|

--- a/db/migrate/20260123132445_add_note_to_events.rb
+++ b/db/migrate/20260123132445_add_note_to_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNoteToEvents < ActiveRecord::Migration[7.1]
   def change
     add_column :events, :note, :text

--- a/db/migrate/20260225163341_remove_sorcery_columns_from_users.rb
+++ b/db/migrate/20260225163341_remove_sorcery_columns_from_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveSorceryColumnsFromUsers < ActiveRecord::Migration[7.1]
   def change
     remove_column :users, :crypted_password, :string

--- a/db/migrate/20260306160259_create_event_participants.rb
+++ b/db/migrate/20260306160259_create_event_participants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateEventParticipants < ActiveRecord::Migration[7.1]
   def change
     create_table :event_participants do |t|

--- a/db/migrate/20260307085044_add_unique_index_to_event_participants.rb
+++ b/db/migrate/20260307085044_add_unique_index_to_event_participants.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexToEventParticipants < ActiveRecord::Migration[7.1]
   def change
-    add_index :event_participants, [:event_id, :user_id], unique: true
+    add_index :event_participants, %i[event_id user_id], unique: true
   end
 end

--- a/db/migrate/20260312080859_create_shops.rb
+++ b/db/migrate/20260312080859_create_shops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateShops < ActiveRecord::Migration[7.1]
   def change
     create_table :shops do |t|

--- a/db/migrate/20260317090054_create_likes.rb
+++ b/db/migrate/20260317090054_create_likes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLikes < ActiveRecord::Migration[7.1]
   def change
     create_table :likes do |t|
@@ -6,6 +8,6 @@ class CreateLikes < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
-    add_index :likes, [:shop_id, :user_id], unique: true
+    add_index :likes, %i[shop_id user_id], unique: true
   end
 end

--- a/db/migrate/20260318142528_add_likes_count_to_shops.rb
+++ b/db/migrate/20260318142528_add_likes_count_to_shops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLikesCountToShops < ActiveRecord::Migration[7.1]
   def change
     add_column :shops, :likes_count, :integer, default: 0, null: false

--- a/db/migrate/20260321155312_add_provider_and_uid_to_users.rb
+++ b/db/migrate/20260321155312_add_provider_and_uid_to_users.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class AddProviderAndUidToUsers < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :provider, :string
     add_column :users, :uid, :string
 
-    add_index :users, [:provider, :uid], unique: true
+    add_index :users, %i[provider uid], unique: true
   end
 end

--- a/db/migrate/20260323054555_create_event_preferences.rb
+++ b/db/migrate/20260323054555_create_event_preferences.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateEventPreferences < ActiveRecord::Migration[7.1]
   def change
     create_table :event_preferences do |t|
@@ -9,6 +11,6 @@ class CreateEventPreferences < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
-    add_index :event_preferences, [:event_id, :user_id], unique: true
+    add_index :event_preferences, %i[event_id user_id], unique: true
   end
 end

--- a/db/migrate/20260324170608_add_place_id_to_shops.rb
+++ b/db/migrate/20260324170608_add_place_id_to_shops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPlaceIdToShops < ActiveRecord::Migration[7.1]
   def change
     add_column :shops, :place_id, :string

--- a/db/migrate/20260331060820_add_log_category_to_shops.rb
+++ b/db/migrate/20260331060820_add_log_category_to_shops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLogCategoryToShops < ActiveRecord::Migration[7.1]
   def change
     add_column :shops, :log_category, :string

--- a/db/migrate/20260401151906_add_log_note_to_shops.rb
+++ b/db/migrate/20260401151906_add_log_note_to_shops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLogNoteToShops < ActiveRecord::Migration[7.1]
   def change
     add_column :shops, :log_note, :text

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :chrome, screen_size: [ 1400, 1400 ]
 end

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module ApplicationCable

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class DashboardControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/event_participants_controller_test.rb
+++ b/test/controllers/event_participants_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EventParticipantsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/event_preferences_controller_test.rb
+++ b/test/controllers/event_preferences_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EventPreferencesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EventsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class LikesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/shop_logs_controller_test.rb
+++ b/test/controllers/shop_logs_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ShopLogsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/shops_controller_test.rb
+++ b/test/controllers/shops_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ShopsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/user_sessions_controller_test.rb
+++ b/test/controllers/user_sessions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserSessionsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
-class Users::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+module Users
+  class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+    # test "the truth" do
+    #   assert true
+    # end
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest

--- a/test/models/event_participant_test.rb
+++ b/test/models/event_participant_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EventParticipantTest < ActiveSupport::TestCase

--- a/test/models/event_preference_test.rb
+++ b/test/models/event_preference_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EventPreferenceTest < ActiveSupport::TestCase

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class EventTest < ActiveSupport::TestCase

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class LikeTest < ActiveSupport::TestCase

--- a/test/models/shop_test.rb
+++ b/test/models/shop_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ShopTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"


### PR DESCRIPTION
## 概要
Rubocopを導入し、コードスタイルの統一とLintチェック環境を構築した。

## 実装内容
- Gemfileに rubocop / rubocop-rails / rubocop-rails-omakase を追加
- bundle install を実行
- .rubocop.yml を作成し omakase 設定を適用
- TargetRubyVersion を 3.3 に設定
- SuggestExtensions を false に設定
- Style/StringLiterals を double_quotes に統一
- bundle exec rubocop を実行し警告内容を確認
- bundle exec rubocop -A を実行し自動修正を適用
- コード全体のフォーマットを整形

## 動作確認
- bundle exec rubocop が実行できること
- bundle exec rubocop 実行時にエラーが出ないこと（no offenses detected）
- Railsアプリが正常に起動すること
- 既存機能に影響がないこと

## 補足
- rubocop-rails-omakase を使用しRails推奨のLintルールを適用
- 重いリファクタ（i18n対応やメソッド分割など）は本Issueでは対象外とし、フォーマット統一を優先
- 今後は開発時に rubocop を実行しコード品質を維持する

Closes #67