### PR TITLE
feat: お店カードの店名表示を見やすく調整

### DIFF
--- a/app/views/events/_shops.html.erb
+++ b/app/views/events/_shops.html.erb
@@ -34,9 +34,9 @@
                 </div>
               </div>
 
-              <div class="flex-1 space-y-4">
-                <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div class="space-y-2">
+              <div class="min-w-0 flex-1 space-y-4">
+                <div class="flex flex-col gap-3">
+                  <div class="min-w-0 space-y-2">
                     <div class="inline-flex items-center gap-2 rounded-full bg-[#fff1eb] px-3 py-1 text-xs font-bold tracking-widest uppercase text-[#c45f3d] border border-[#f3c8b8]">
                       <span class="material-symbols-outlined text-sm">storefront</span>
                       <%= t("views.events.shops.candidate_badge", number: index + 1) %>
@@ -45,7 +45,7 @@
                     <p class="text-sm text-base-content/50"><%= t("views.events.shops.owner", name: shop.user.name) %></p>
                   </div>
 
-                  <div class="inline-flex items-center gap-2 rounded-2xl bg-white/90 border border-[#f3c8b8] px-4 py-3 text-sm font-semibold text-base-content/70 shrink-0">
+                  <div class="inline-flex w-fit items-center gap-2 rounded-2xl bg-white/90 border border-[#f3c8b8] px-4 py-3 text-sm font-semibold text-base-content/70">
                     <span class="material-symbols-outlined text-[#e3744b]">favorite</span>
                     <span><%= shop.likes_count %></span>
                   </div>


### PR DESCRIPTION
## 概要
お店カード内で店名が早く改行されていたため、カード上段の情報配置を整理して店名を見やすく調整した。

## 実装内容
- お店カード本文カラムに `min-w-0` を追加
- 店名ブロックといいね数の横並びをやめて縦配置に変更
- いいね数ボックスを必要幅だけ使う形に調整
- 店名がより広い幅で表示されるように整理

## 動作確認
- [x] 店名が以前より広い幅で表示される
- [x] いいね数が店名の横幅を圧迫しない
- [x] PC幅でお店カードの見た目が崩れない
- [x] スマホ幅でレイアウトが崩れない

## 補足
- 今回はお店カードの可読性改善のみ
- OGP画像表示や URL からの店名補助入力は別 issue で対応予定

Close #53 
Related to #72
