### PR TITLE
お店URLから店名を補助入力できるようにする

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -71,6 +71,6 @@ class ShopsController < ApplicationController
   end
 
   def shop_params
-    params.require(:shop).permit(:name, :url, :address, :memo)
+    params.require(:shop).permit(:name, :url, :memo)
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -13,6 +13,14 @@ class ShopsController < ApplicationController
 
   def edit; end
 
+  def fetch_name
+    url = params[:url].to_s.strip
+    result = ShopNameFetcher.call(url)
+    status = result.error.present? ? :unprocessable_content : :ok
+
+    render json: { name: result.name, error: result.error }, status: status
+  end
+
   def create
     @shop = @event.shops.new(shop_params)
     @shop.user = current_user

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("hello", HelloController)
 
 import AutocompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
+
+import ShopNameFetchController from "./shop_name_fetch_controller"
+application.register("shop-name-fetch", ShopNameFetchController)

--- a/app/javascript/controllers/shop_name_fetch_controller.js
+++ b/app/javascript/controllers/shop_name_fetch_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["url", "name", "message", "button"]
+  static values = { endpoint: String }
+
+  async fetch(event) {
+    event.preventDefault()
+
+    const url = this.urlTarget.value.trim()
+
+    if (!url) {
+      this.showMessage("URLを入力してください", false)
+      return
+    }
+
+    this.buttonTarget.disabled = true
+
+    try {
+      const response = await window.fetch(this.endpointValue, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content
+        },
+        body: JSON.stringify({ url })
+      })
+
+      const data = await response.json()
+
+      if (response.ok && data.name) {
+        this.nameTarget.value = data.name
+        this.showMessage("店名候補を反映しました", true)
+      } else {
+        this.showMessage(data.error || "店名候補を取得できませんでした", false)
+      }
+    } catch (_error) {
+      this.showMessage("店名取得中にエラーが発生しました", false)
+    } finally {
+      this.buttonTarget.disabled = false
+    }
+  }
+
+  showMessage(message, success) {
+    this.messageTarget.textContent = message
+    this.messageTarget.classList.remove("hidden", "text-base-content/50", "text-[#c45f3d]", "text-[#5f7d4e]")
+    this.messageTarget.classList.add(success ? "text-[#5f7d4e]" : "text-[#c45f3d]")
+  }
+}

--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class ShopNameFetcher
+  Result = Struct.new(:name, :error, keyword_init: true)
+
+  def self.call(url)
+    new(url).call
+  end
+
+  def initialize(url)
+    @url = url.to_s.strip
+  end
+
+  def call
+    return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_blank_url")) if @url.blank?
+
+    response = Faraday.get(@url)
+    return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed")) unless response.success?
+
+    candidate_name = extract_name(response.body)
+    return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_not_found")) if candidate_name.blank?
+
+    Result.new(name: candidate_name, error: nil)
+  rescue Faraday::Error
+    Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed"))
+  rescue StandardError
+    Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_unexpected_error"))
+  end
+
+  private
+
+  def extract_name(body)
+    document = Nokogiri::HTML(body)
+
+    og_title = document.at_css('meta[property="og:title"]')&.[]("content")&.strip
+    return og_title if og_title.present?
+
+    document.at_css("title")&.text&.strip
+  end
+end

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -25,25 +25,47 @@
         <div class="relative z-10">
           <%= render "shared/error_messages", resource: shop %>
 
-          <%= form_with model: [event, shop], local: true do |f| %>
+          <%= form_with model: [event, shop], local: true,
+                data: {
+                  controller: "shop-name-fetch",
+                  "shop-name-fetch-endpoint-value": fetch_name_event_shops_path(event)
+                } do |f| %>
             <div class="space-y-6">
-              <div class="form-control">
-                <%= f.label :name, t("#{translation_scope}.name_label"), class: "label text-xs font-bold tracking-widest uppercase text-base-content/60" %>
-                <label class="input input-bordered flex w-full items-center gap-3 rounded-2xl bg-base-100 shadow-sm">
-                  <span class="material-symbols-outlined text-[#e3744b]">storefront</span>
-                  <%= f.text_field :name,
-                        class: "grow border-0 p-0 focus:outline-none",
-                        placeholder: t("#{translation_scope}.name_placeholder") %>
-                </label>
-              </div>
-
               <div class="form-control">
                 <%= f.label :url, t("#{translation_scope}.url_label"), class: "label text-xs font-bold tracking-widest uppercase text-base-content/60" %>
                 <label class="input input-bordered flex w-full items-center gap-3 rounded-2xl bg-base-100 shadow-sm">
                   <span class="material-symbols-outlined text-[#e3744b]">link</span>
                   <%= f.url_field :url,
+                        data: { "shop-name-fetch-target": "url" },
                         class: "grow border-0 p-0 focus:outline-none",
                         placeholder: t("#{translation_scope}.url_placeholder") %>
+                </label>
+
+                <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <button type="button"
+                    data-action="shop-name-fetch#fetch"
+                    data-shop-name-fetch-target="button"
+                    class="btn btn-outline rounded-full border-[#d7cdbc] text-base-content/70 hover:bg-amber-50">
+                    <%= t("views.shops.form.fetch_name_button") %>
+                  </button>
+                  <p class="text-sm text-base-content/50">
+                    <%= t("views.shops.form.fetch_name_hint") %>
+                  </p>
+                </div>
+
+                <p class="mt-2 hidden text-sm text-base-content/50" data-shop-name-fetch-target="message">
+                  <%= t("views.shops.form.fetch_name_idle") %>
+                </p>
+              </div>
+
+              <div class="form-control">
+                <%= f.label :name, t("#{translation_scope}.name_label"), class: "label text-xs font-bold tracking-widest uppercase text-base-content/60" %>
+                <label class="input input-bordered flex w-full items-center gap-3 rounded-2xl bg-base-100 shadow-sm">
+                  <span class="material-symbols-outlined text-[#e3744b]">storefront</span>
+                  <%= f.text_field :name,
+                        data: { "shop-name-fetch-target": "name" },
+                        class: "grow border-0 p-0 focus:outline-none",
+                        placeholder: t("#{translation_scope}.name_placeholder") %>
                 </label>
               </div>
 

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -48,16 +48,6 @@
               </div>
 
               <div class="form-control">
-                <%= f.label :address, t("#{translation_scope}.address_label"), class: "label text-xs font-bold tracking-widest uppercase text-base-content/60" %>
-                <label class="input input-bordered flex w-full items-center gap-3 rounded-2xl bg-base-100 shadow-sm">
-                  <span class="material-symbols-outlined text-[#e3744b]">location_on</span>
-                  <%= f.text_field :address,
-                        class: "grow border-0 p-0 focus:outline-none",
-                        placeholder: t("#{translation_scope}.address_placeholder") %>
-                </label>
-              </div>
-
-              <div class="form-control">
                 <%= f.label :memo, t("#{translation_scope}.memo_label"), class: "label text-xs font-bold tracking-widest uppercase text-base-content/60" %>
                 <label class="textarea textarea-bordered flex min-h-36 items-start gap-3 rounded-2xl bg-base-100 py-4 shadow-sm">
                   <span class="material-symbols-outlined mt-1 text-[#e3744b]">edit_note</span>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,8 @@ module Myapp
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_paths << Rails.root.join("app/services")
+    config.eager_load_paths << Rails.root.join("app/services")
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -207,6 +207,14 @@ ja:
         open_google_map: "Google Mapで開く"
         empty: "まだお店候補はありません"
     shops:
+      form:
+        fetch_name_button: "URLから店名を取得"
+        fetch_name_hint: "取得後も手入力で修正できます"
+        fetch_name_idle: "URLを入力してから店名取得ボタンを押してください"
+        fetch_name_blank_url: "URLを入力してください"
+        fetch_name_request_failed: "ページ情報を取得できませんでした"
+        fetch_name_not_found: "店名候補を取得できませんでした"
+        fetch_name_unexpected_error: "店名取得中にエラーが発生しました"
       new:
         hero_badge: "Restaurant Candidate"
         title: "お店候補を登録"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,8 +215,6 @@ ja:
         name_placeholder: "お店の名前"
         url_label: "リンク"
         url_placeholder: "食べログや公式サイトのURL"
-        address_label: "住所（任意）"
-        address_placeholder: "渋谷○丁目あたり / 新宿駅周辺 など"
         memo_label: "メモ"
         memo_placeholder: "おすすめメニューや選んだ理由、雰囲気のメモなど"
       edit:
@@ -227,8 +225,6 @@ ja:
         name_placeholder: "お店の名前"
         url_label: "お店のURL"
         url_placeholder: "食べログや公式サイトのURL"
-        address_label: "住所（任意）"
-        address_placeholder: "渋谷○丁目あたり / 新宿駅周辺 など"
         memo_label: "メモ"
         memo_placeholder: "おすすめメニューや選んだ理由、雰囲気のメモなど"
     dashboard:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
     resources :event_preferences, only: %i[create destroy]
 
     resources :shops, only: %i[new create edit update destroy] do
+      collection do
+        post :fetch_name
+      end
       resource :like, only: %i[create destroy]
     end
   end


### PR DESCRIPTION
## 概要
お店登録フォームで URL を入力すると、ページ情報をもとに店名候補を補助入力できるようにした。
あわせて、URL 起点で入力しやすいようにフォーム導線を整理し、現状未使用だった住所欄も削除した。

## 実装内容
- お店フォームの入力順を URL → 店名 → メモ に整理
- `URLから店名を取得` ボタンと補助メッセージを追加
- 店名取得用の route と controller action を追加
- URL 先の `og:title` / `title` を読む `ShopNameFetcher` を追加
- Stimulus で非同期に店名候補を取得し、店名欄へ反映する処理を追加
- `app/services` を autoload / eager_load 対象に追加
- 関連する i18n 文言を追加
- 地図表示やカード表示では未使用だった住所欄をフォーム / strong parameters / i18n から削除

## 動作確認
- [x] URL を入力して `URLから店名を取得` を押すと店名候補を取得できる
- [x] 取得した店名候補が店名欄に反映される
- [x] URL 未入力時にメッセージが表示される
- [x] 取得失敗時も手入力で登録を続けられる
- [x] 取得後に店名を手入力で修正して保存できる
- [x] 新規作成画面 / 編集画面の両方で導線が崩れない
- [x] PC / スマホでフォームレイアウトが崩れない
- [x] 住所欄がフォームから削除されている

## 補足
- 店名取得は補助入力として実装しており、最終的な確認や修正はユーザーが行う前提
- サイトによっては `og:title` や `title` の内容が長めに取得されることがある

Closes #109
