### PR TITLE
Feat: shop ogp image

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -26,6 +26,7 @@ class ShopsController < ApplicationController
     @shop.user = current_user
 
     @shop.place_id = @shop.fetch_place_id(@event.place)
+    @shop.ogp_image_url = fetch_ogp_image_url(@shop.url)
 
     if @shop.save
       redirect_to event_path(@event), notice: t("flash.shops.create.notice")
@@ -42,6 +43,10 @@ class ShopsController < ApplicationController
     if @shop.will_save_change_to_name?
       new_place_id = @shop.fetch_place_id(@event.place)
       @shop.place_id = new_place_id if new_place_id.present?
+    end
+
+    if @shop.will_save_change_to_url? || @shop.ogp_image_url.blank?
+      @shop.ogp_image_url = fetch_ogp_image_url(@shop.url)
     end
 
     if @shop.save
@@ -80,5 +85,11 @@ class ShopsController < ApplicationController
 
   def shop_params
     params.require(:shop).permit(:name, :url, :memo)
+  end
+
+  def fetch_ogp_image_url(url)
+    return if url.blank?
+
+    ShopOgpImageFetcher.call(url).image_url
   end
 end

--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ShopNameFetcher
   Result = Struct.new(:name, :error, keyword_init: true)
 

--- a/app/services/shop_ogp_image_fetcher.rb
+++ b/app/services/shop_ogp_image_fetcher.rb
@@ -1,0 +1,39 @@
+class ShopOgpImageFetcher
+  Result = Struct.new(:image_url, :error, keyword_init: true)
+
+  def self.call(url)
+    new(url).call
+  end
+
+  def initialize(url)
+    @url = url.to_s.strip
+  end
+
+  def call
+    return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.blank_url")) if @url.blank?
+
+    response = Faraday.get(@url)
+    return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.request_failed")) unless response.success?
+
+    image_url = extract_image_url(response.body)
+    return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.not_found")) if image_url.blank?
+
+    Result.new(image_url:, error: nil)
+  rescue Faraday::Error
+    Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.request_failed"))
+  rescue StandardError
+    Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.unexpected_error"))
+  end
+
+  private
+
+  def extract_image_url(body)
+    document = Nokogiri::HTML(body)
+    raw_image_url = document.at_css('meta[property="og:image"]')&.[]("content")&.strip
+    return if raw_image_url.blank?
+
+    URI.join(@url, raw_image_url).to_s
+  rescue URI::InvalidURIError
+    nil
+  end
+end

--- a/app/views/events/_shops.html.erb
+++ b/app/views/events/_shops.html.erb
@@ -21,16 +21,22 @@
             <div class="flex flex-col gap-5 xl:flex-row xl:items-stretch xl:justify-between">
               <div class="xl:w-[220px] 2xl:w-[240px] shrink-0">
                 <div class="h-56 xl:h-full min-h-56 overflow-hidden rounded-[1.5rem] border border-[#f3c8b8] bg-gradient-to-br from-stone-100 via-[#f7f2ec] to-[#fff1eb] relative">
-                  <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.9),transparent_45%),radial-gradient(circle_at_bottom_right,rgba(251,146,60,0.16),transparent_40%)]"></div>
-                  <div class="absolute inset-0 flex flex-col items-center justify-center text-center p-6">
-                    <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/90 text-[#e3744b] shadow-sm">
-                      <span class="material-symbols-outlined text-3xl">photo</span>
+                  <% if shop.ogp_image_url.present? %>
+                    <%= image_tag shop.ogp_image_url,
+                      alt: shop.name,
+                      class: "h-full w-full object-cover" %>
+                    <div class="pointer-events-none absolute inset-0 bg-[linear-gradient(to_top,rgba(59,40,22,0.12),transparent_45%)]"></div>
+                  <% else %>
+                    <div class="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.9),transparent_45%),radial-gradient(circle_at_bottom_right,rgba(251,146,60,0.16),transparent_40%)]"></div>
+                    <div class="absolute inset-0 flex flex-col items-center justify-center text-center p-6 translate-y-4">
+                      <div class="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/90 text-[#e3744b] shadow-sm">
+                        <span class="material-symbols-outlined text-[2.25rem]">photo</span>
+                      </div>
+                      <p class="mt-3 text-xs leading-relaxed text-base-content/60">
+                        <%= t("views.events.shops.image_placeholder_body") %>
+                      </p>
                     </div>
-                    <p class="mt-4 text-sm font-semibold text-stone-700"><%= t("views.events.shops.image_placeholder_title") %></p>
-                    <p class="mt-2 text-xs leading-relaxed text-base-content/60">
-                      <%= t("views.events.shops.image_placeholder_body") %>
-                    </p>
-                  </div>
+                  <% end %>
                 </div>
               </div>
 

--- a/app/views/shop_logs/index.html.erb
+++ b/app/views/shop_logs/index.html.erb
@@ -107,14 +107,22 @@
           <article class="overflow-hidden rounded-[2rem] border border-[#d7cdbc] bg-base-100 shadow-xl shadow-stone-200/20">
             <div class="grid gap-0 xl:grid-cols-[300px_minmax(0,1fr)] 2xl:grid-cols-[340px_minmax(0,1fr)]">
               <div class="relative min-h-[240px] overflow-hidden border-b border-[#d7cdbc] bg-[#fffaf3] xl:min-h-full xl:border-b-0 xl:border-r">
-                <div class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(0,0,0,0.12))]"></div>
-
-                <div class="relative flex h-full items-end p-5">
-                  <div class="w-full rounded-3xl border border-white/70 bg-white/80 p-5 shadow-sm backdrop-blur-sm">
-                    <p class="text-xs font-bold uppercase tracking-widest text-[#7a6757]"><%= t("views.shop_logs.index.image_placeholder_title") %></p>
-                    <p class="mt-3 text-sm leading-relaxed text-[#6f5f52]"><%= t("views.shop_logs.index.image_placeholder_body") %></p>
+                <% if shop.ogp_image_url.present? %>
+                  <%= image_tag shop.ogp_image_url,
+                    alt: shop.name,
+                    class: "absolute inset-0 h-full w-full object-cover" %>
+                  <div class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(0,0,0,0.18))]"></div>
+                <% else %>
+                  <div class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.02),rgba(0,0,0,0.12))]"></div>
+                  <div class="absolute inset-0 flex flex-col items-center justify-center text-center p-6 translate-y-4">
+                    <div class="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/90 text-[#e3744b] shadow-sm">
+                      <span class="material-symbols-outlined text-[2.25rem]">photo</span>
+                    </div>
+                    <p class="mt-3 text-sm leading-relaxed text-[#6f5f52]">
+                      <%= t("views.shop_logs.index.image_placeholder_body") %>
+                    </p>
                   </div>
-                </div>
+                <% end %>
               </div>
 
               <div class="p-6 lg:p-7">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -292,7 +292,7 @@ ja:
         category_all: "すべて"
         reset: "リセット"
         image_placeholder_title: "お店のイメージ画像"
-        image_placeholder_body: "将来ここに OGP 画像を表示して、ログをもっと見返しやすくしたいです。"
+        image_placeholder_body: "URL先に画像がないため表示されません"
         uncategorized_badge: "LOG"
         open_shop_page: "お店のページを見る"
         shop_memo_label: "候補メモ"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,12 @@ ja:
   app:
     name: "ごはん会議"
     title: "ごはん会議"
+  services:
+    shop_ogp_image_fetcher:
+      blank_url: "URLを入力してください"
+      request_failed: "ページ情報を取得できませんでした"
+      not_found: "OGP画像を取得できませんでした"
+      unexpected_error: "OGP画像取得中にエラーが発生しました"
   defaults:
     line_user_name: "LINEユーザー"
 
@@ -192,7 +198,7 @@ ja:
         section_label: "Candidates"
         description: "候補を見比べて、気になるお店にいいねできます。"
         image_placeholder_title: "お店のイメージ画像"
-        image_placeholder_body: "将来ここに OGP 画像を表示できるようにしたいです。"
+        image_placeholder_body: "URL先に画像がないため表示されません"
         sort_created: "登録順"
         sort_likes: "いいね順"
         new_shop: "お店候補を登録"

--- a/db/migrate/20260419090000_add_ogp_image_url_to_shops.rb
+++ b/db/migrate/20260419090000_add_ogp_image_url_to_shops.rb
@@ -1,0 +1,5 @@
+class AddOgpImageUrlToShops < ActiveRecord::Migration[7.1]
+  def change
+    add_column :shops, :ogp_image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_01_151906) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_19_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_01_151906) do
     t.string "place_id"
     t.string "log_category"
     t.text "log_note"
+    t.string "ogp_image_url"
     t.index ["event_id"], name: "index_shops_on_event_id"
     t.index ["user_id"], name: "index_shops_on_user_id"
   end


### PR DESCRIPTION
## 概要
お店 URL をもとに OGP 画像 URL を取得して保存し、イベント詳細のお店候補カードとお店ログ画面で表示できるようにした。
あわせて、画像が取得できない場合でも見た目が崩れないようにプレースホルダー表示を整理した。

## 実装内容
- `shops` テーブルに `ogp_image_url` カラムを追加
- URL 先の `og:image` を取得する `ShopOgpImageFetcher` を追加
- お店作成時に OGP 画像 URL を保存するように変更
- お店編集時は URL 変更時、または `ogp_image_url` が空の場合に再取得するように変更
- イベント詳細のお店候補カードで OGP 画像を表示するように変更
- お店ログ画面でも OGP 画像を表示するように変更
- OGP 画像がない場合のプレースホルダー表示と文言を調整

## 動作確認
- [x] お店 URL から `og:image` を取得できる
- [x] 新規作成したお店で OGP 画像が保存され、イベント詳細に表示される
- [x] 既存のお店でも編集保存時に OGP 画像を補完できる
- [x] OGP 画像があるお店はイベント詳細で実画像が表示される
- [x] OGP 画像がないお店はイベント詳細でプレースホルダーが表示される
- [x] OGP 画像があるお店はお店ログ画面でも実画像が表示される
- [x] OGP 画像がないお店はお店ログ画面でプレースホルダーが表示される
- [x] PC / スマホでレイアウトが崩れない

## 補足
- OGP 画像取得に失敗してもお店の登録 / 更新自体は止めない
- URL 先に `og:image` がない場合はプレースホルダー表示にフォールバックする
- お店ログ画面のプレースホルダーは、背景はそのままにして中身の構成をお店候補側に寄せている

Closes #110
