### PR TITLE
feat: イベント編集権限を制御して非作成者アクセス導線を修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,8 +2,8 @@
 
 class EventsController < ApplicationController
   before_action :authenticate_user!, except: %i[join]
-  before_action :set_event, only: %i[show]
-  before_action :set_current_user_event, only: %i[edit update destroy]
+  before_action :set_event, only: %i[show edit update destroy]
+  before_action :ensure_event_owner!, only: %i[edit update destroy]
 
   def index
     @events = current_user.events.order(created_at: :desc)
@@ -88,11 +88,13 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
   end
 
-  def set_current_user_event
-    @event = current_user.events.find(params[:id])
-  end
-
   def event_params
     params.require(:event).permit(:title, :event_date, :event_time, :place, :note)
+  end
+
+  def ensure_event_owner!
+    return if @event.user == current_user
+
+    redirect_to event_path(@event), alert: t("flash.events.owner_only.alert"), status: :see_other
   end
 end

--- a/app/views/events/_event_header.html.erb
+++ b/app/views/events/_event_header.html.erb
@@ -50,11 +50,13 @@
 
       <div class="flex flex-wrap items-center gap-2 lg:max-w-xs lg:justify-end">
         <%= link_to t("views.events.show.back_to_index"), events_path, class: "btn rounded-full bg-white/70 text-stone-700 border border-stone-200 hover:bg-white/90 shadow-sm backdrop-blur-sm" %>
-        <%= link_to t("common.edit"), edit_event_path(event), class: "btn rounded-full bg-white/82 text-stone-700 border border-stone-200 hover:bg-white shadow-sm" %>
-        <%= link_to t("common.delete"),
-                    event_path(event),
-                    data: { turbo_method: :delete, turbo_confirm: t("views.events.show.delete_confirm") },
-                    class: "btn rounded-full bg-red-50 text-red-600 border border-red-100 hover:bg-red-100" %>
+        <% if current_user == event.user %>
+          <%= link_to t("common.edit"), edit_event_path(event), class: "btn rounded-full bg-white/82 text-stone-700 border border-stone-200 hover:bg-white shadow-sm" %>
+          <%= link_to t("common.delete"),
+                      event_path(event),
+                      data: { turbo_method: :delete, turbo_confirm: t("views.events.show.delete_confirm") },
+                      class: "btn rounded-full bg-red-50 text-red-600 border border-red-100 hover:bg-red-100" %>
+        <% end %>
       </div>
     </div>
 

--- a/config/locales/ja.flash.yml
+++ b/config/locales/ja.flash.yml
@@ -3,6 +3,8 @@ ja:
     events:
       not_found:
         alert: "イベントが見つかりませんでした"
+      owner_only:
+        alert: "イベント編集はイベント作成者のみ可能です"
       join_requires_auth:
         alert: "イベントに参加するにはログインまたは新規登録が必要です"
       create:


### PR DESCRIPTION
## 概要
イベント作成者ではないユーザーが共有URL経由などでイベント詳細にアクセスした場合に、編集URLや削除相当のリクエストを直接送ってもエラー画面にならないようにした。
あわせて、非作成者にはイベント詳細で編集 / 削除ボタンを表示しないようにして、権限不足時には alert で案内するようにした。

## 実装内容
- イベント詳細の編集 / 削除ボタンをイベント作成者本人のときだけ表示するように変更
- `edit / update / destroy` にイベント作成者チェックを追加
- 非作成者が直接アクセスした場合はイベント詳細へ戻して alert を表示するように変更
- `DELETE` リクエスト時にリダイレクトループしないよう `status: :see_other` を追加
- 権限不足時の alert 文言を i18n に追加

## 動作確認
- [x] イベント作成者本人では、イベント詳細に編集 / 削除ボタンが表示される
- [x] イベント作成者本人では、編集画面へ通常どおり遷移できる
- [x] 非作成者では、イベント詳細に編集 / 削除ボタンが表示されない
- [x] 非作成者が編集URLへ直接アクセスした場合、イベント詳細へ戻る
- [x] その際、適切な alert メッセージが表示される
- [x] 非作成者が削除相当のリクエストを送っても、イベントは削除されずイベント詳細へ戻る

## 補足
- 非作成者の destroy 相当リクエスト確認では、ブラウザ Console から `DELETE /events/:id` を送って挙動を確認した
- 権限制御は view 側の非表示だけでなく、controller 側でも `edit / update / destroy` をガードしている

Closes #106
