### PR TITLE
feat: ログイン済みユーザーの認証画面アクセス導線を改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,12 +11,12 @@ class ApplicationController < ActionController::Base
   end
 
   # ログイン後の遷移先
-  def after_sign_in_path_for(_resource)
-    stored_location_for(resource) || dashboard_path
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || dashboard_path
   end
 
   # 新規登録後の遷移先
-  def after_sign_up_path_for(_resource)
-    stored_location_for(resource) || dashboard_path
+  def after_sign_up_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || dashboard_path
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,11 @@
+class Users::PasswordsController < Devise::PasswordsController
+  before_action :redirect_if_authenticated, only: %i[new edit]
+
+  private
+
+  def redirect_if_authenticated
+    return unless user_signed_in?
+
+    redirect_to dashboard_path, alert: t("flash.devise.already_authenticated.alert")
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :redirect_if_authenticated, only: %i[new]
+
+  private
+
+  def redirect_if_authenticated
+    return unless user_signed_in?
+
+    redirect_to dashboard_path, alert: t("flash.devise.already_authenticated.alert")
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,11 @@
+class Users::SessionsController < Devise::SessionsController
+  before_action :redirect_if_authenticated, only: %i[new]
+
+  private
+
+  def redirect_if_authenticated
+    return unless user_signed_in?
+
+    redirect_to dashboard_path, alert: t("flash.devise.already_authenticated.alert")
+  end
+end

--- a/config/locales/ja.flash.yml
+++ b/config/locales/ja.flash.yml
@@ -51,3 +51,6 @@ ja:
         notice: "LINEでログインしました"
       line_login_failed:
         alert: "LINEログインに失敗しました"
+    devise:
+      already_authenticated:
+        alert: "すでにログインしています"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@
 
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    omniauth_callbacks: "users/omniauth_callbacks"
+    omniauth_callbacks: "users/omniauth_callbacks",
+    sessions: "users/sessions",
+    registrations: "users/registrations",
+    passwords: "users/passwords"
   }
   root "static_pages#top"
 


### PR DESCRIPTION
## 概要
ログイン済みユーザーが新規登録画面・ログイン画面・パスワード再設定画面へアクセスした場合に、開発者向けエラーや不自然な認証導線にならないように改善した。
認証済みユーザーは `dashboard` へリダイレクトし、必要に応じて alert で案内するようにした。

## 実装内容
- `sessions` / `registrations` / `passwords` の custom controller を追加
- ログイン済みユーザーが認証画面 (`new` / `edit`) にアクセスした場合は `dashboard` へ redirect するように変更
- `すでにログインしています` の alert 文言を追加
- `devise_for` の routing を custom controller に切り替え
- `after_sign_in_path_for` / `after_sign_up_path_for` の引数扱いを修正

## 動作確認
- [x] 未ログインユーザーは新規登録画面へ通常どおりアクセスできる
- [x] 未ログインユーザーはログイン画面へ通常どおりアクセスできる
- [x] 未ログインユーザーはパスワード再設定画面へ通常どおりアクセスできる
- [x] ログイン済みユーザーが新規登録画面へアクセスしてもエラーにならない
- [x] ログイン済みユーザーがログイン画面へアクセスしてもエラーにならない
- [x] ログイン済みユーザーがパスワード再設定画面へアクセスしてもエラーにならない
- [x] ログイン済みユーザーは `dashboard` へリダイレクトされる
- [x] 必要に応じて `すでにログインしています` の alert が表示される

## 補足
- 今回は認証画面へのアクセス制御に絞って対応しており、static_page 自体の redirect は対象外としている
- `ApplicationController` の `after_sign_in_path_for` / `after_sign_up_path_for` で、`stored_location_for` に渡す引数の扱いもあわせて修正した

Closes #107
