### PR TITLE
feat: お店候補登録まわりにローディング表示を追加する

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,6 @@ application.register("autocomplete", AutocompleteController)
 
 import ShopNameFetchController from "./shop_name_fetch_controller"
 application.register("shop-name-fetch", ShopNameFetchController)
+
+import ShopSubmitController from "./shop_submit_controller"
+application.register("shop-submit", ShopSubmitController)

--- a/app/javascript/controllers/shop_name_fetch_controller.js
+++ b/app/javascript/controllers/shop_name_fetch_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["url", "name", "message", "button"]
+  static targets = ["url", "name", "message", "button", "buttonLabel", "buttonSpinner"]
   static values = { endpoint: String }
 
   async fetch(event) {
@@ -14,7 +14,7 @@ export default class extends Controller {
       return
     }
 
-    this.buttonTarget.disabled = true
+    this.startLoading()
 
     try {
       const response = await window.fetch(this.endpointValue, {
@@ -37,7 +37,7 @@ export default class extends Controller {
     } catch (_error) {
       this.showMessage("店名取得中にエラーが発生しました", false)
     } finally {
-      this.buttonTarget.disabled = false
+      this.stopLoading()
     }
   }
 
@@ -45,5 +45,17 @@ export default class extends Controller {
     this.messageTarget.textContent = message
     this.messageTarget.classList.remove("hidden", "text-base-content/50", "text-[#c45f3d]", "text-[#5f7d4e]")
     this.messageTarget.classList.add(success ? "text-[#5f7d4e]" : "text-[#c45f3d]")
+  }
+
+  startLoading() {
+    this.buttonTarget.disabled = true
+    this.buttonLabelTarget.textContent = this.buttonTarget.dataset.loadingText
+    this.buttonSpinnerTarget.classList.remove("hidden")
+  }
+
+  stopLoading() {
+    this.buttonTarget.disabled = false
+    this.buttonLabelTarget.textContent = this.buttonTarget.dataset.defaultText
+    this.buttonSpinnerTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/shop_submit_controller.js
+++ b/app/javascript/controllers/shop_submit_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "buttonLabel", "buttonSpinner"]
+
+  submit() {
+    this.buttonTarget.disabled = true
+    this.buttonLabelTarget.textContent = this.buttonTarget.dataset.loadingText
+    this.buttonSpinnerTarget.classList.remove("hidden")
+  }
+}

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -27,7 +27,8 @@
 
           <%= form_with model: [event, shop], local: true,
                 data: {
-                  controller: "shop-name-fetch",
+                  controller: "shop-name-fetch shop-submit",
+                  action: "submit->shop-submit#submit",
                   "shop-name-fetch-endpoint-value": fetch_name_event_shops_path(event)
                 } do |f| %>
             <div class="space-y-6">
@@ -45,8 +46,11 @@
                   <button type="button"
                     data-action="shop-name-fetch#fetch"
                     data-shop-name-fetch-target="button"
+                    data-default-text="<%= t("views.shops.form.fetch_name_button") %>"
+                    data-loading-text="<%= t("views.shops.form.fetch_name_loading") %>"
                     class="btn btn-outline rounded-full border-[#d7cdbc] text-base-content/70 hover:bg-amber-50">
-                    <%= t("views.shops.form.fetch_name_button") %>
+                    <span class="loading loading-spinner loading-xs hidden" data-shop-name-fetch-target="buttonSpinner"></span>
+                    <span data-shop-name-fetch-target="buttonLabel"><%= t("views.shops.form.fetch_name_button") %></span>
                   </button>
                   <p class="text-sm text-base-content/50">
                     <%= t("views.shops.form.fetch_name_hint") %>
@@ -82,7 +86,16 @@
               </div>
 
               <div class="pt-2">
-                <%= f.submit submit_label, class: "btn w-full rounded-full border-none bg-[#e3744b] text-white hover:bg-[#cf643d] shadow-lg shadow-orange-200/35" %>
+                <%= f.button :submit,
+                      class: "btn w-full rounded-full border-none bg-[#e3744b] text-white hover:bg-[#cf643d] shadow-lg shadow-orange-200/35",
+                      data: {
+                        "shop-submit-target": "button",
+                        default_text: submit_label,
+                        loading_text: shop.persisted? ? t("views.shops.form.submit_loading_update") : t("views.shops.form.submit_loading_create")
+                      } do %>
+                  <span class="loading loading-spinner loading-xs hidden" data-shop-submit-target="buttonSpinner"></span>
+                  <span data-shop-submit-target="buttonLabel"><%= submit_label %></span>
+                <% end %>
               </div>
             </div>
           <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -219,12 +219,15 @@ ja:
     shops:
       form:
         fetch_name_button: "URLから店名を取得"
+        fetch_name_loading: "取得中..."
         fetch_name_hint: "取得後も手入力で修正できます"
         fetch_name_idle: "URLを入力してから店名取得ボタンを押してください"
         fetch_name_blank_url: "URLを入力してください"
         fetch_name_request_failed: "ページ情報を取得できませんでした"
         fetch_name_not_found: "店名候補を取得できませんでした"
         fetch_name_unexpected_error: "店名取得中にエラーが発生しました"
+        submit_loading_create: "登録中..."
+        submit_loading_update: "更新中..."
       new:
         hero_badge: "Restaurant Candidate"
         title: "お店候補を登録"


### PR DESCRIPTION
## 概要
お店候補登録まわりで待ち時間が発生しやすい処理にローディング表示を追加した。
まずは `URLから店名を取得` とお店候補の保存 / 更新に対象を絞り、処理中であることが分かるようにした。

## 実装内容
- `URLから店名を取得` ボタン押下時にローディング表示を追加
- 店名取得中はボタンを連続で押せないように変更
- お店候補の保存 / 更新時にローディング表示を追加
- 保存 / 更新中は二重送信しにくいように調整
- ローディング中の文言を追加

## 動作確認
- [x] `URLから店名を取得` 実行中に処理中だと分かる表示になる
- [x] 店名取得完了後にローディング表示が元に戻る
- [x] お店候補の保存 / 更新中に処理中だと分かる表示になる
- [x] 保存 / 更新完了後にローディング表示が解除される
- [x] ボタンの二重押し / 二重送信が起きにくい
- [x] PC / スマホでローディング表示が不自然にならない

## 補足
- 対象はお店候補登録まわりの重い処理に限定している
- 派手なアニメーションではなく、ボタン内の小さいスピナーと文言変更で対応している

Closes #73