### PR TITLE
feat: Neonを本番DBとして利用できるよう設定を整理

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,22 +2,23 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
-  username: postgres
-  password: password
 
 development:
   <<: *default
+  host: db
+  username: postgres
+  password: password
   database: myapp_development
 
 test:
   <<: *default
+  host: db
+  username: postgres
+  password: password
   database: myapp_test
 
 production:
   <<: *default
-  database: myapp_production
-  username: myapp
-  password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  url: <%= ENV["DATABASE_URL"] %>
 
   


### PR DESCRIPTION
## 概要
本番環境で Render の PostgreSQL ではなく Neon を利用できるよう、DB 接続設定を整理した。
あわせて本番環境の LINE ログイン設定も見直し、callback URL を含めて正常にログインできる状態を確認した。

## 実装内容
- `config/database.yml` を環境ごとに整理
- `default` を共通設定のみに変更
- `development` / `test` に Docker 用の接続設定を明示
- `production` では `DATABASE_URL` を使うように変更
- Neon を本番 DB として利用できる前提を整備

## 動作確認
- [ ] Render 上でデプロイが成功する
- [ ] 本番環境でアプリが起動する
- [ ] production が `DATABASE_URL` 経由で DB 接続できる
- [ ] 本番環境で LINE ログインできる

## 補足
- Render の `DATABASE_URL` は Neon の接続文字列に更新済み
- Render に `LINE_CHANNEL_ID` / `LINE_CHANNEL_SECRET` を設定済み
- LINE Developers Console の callback URL を本番 URL に更新済み
- 旧 Render DB は残っていない前提で、新しい本番 DB として Neon を利用している

Close #129 