### PR TITLE
feat: OGP文言を調整する

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,16 +2,12 @@
 
 module EventsHelper
   def event_ogp_title(event)
-    "#{event.title} | #{t('app.title')}"
+    title_date = l(event.event_date)
+    title_date += " #{event.event_time.strftime('%H:%M')}" if event.event_time.present?
+    "#{t('app.title')}｜#{title_date}"
   end
 
   def event_ogp_description(event)
-    details = [ l(event.event_date) ]
-    details << event.event_time.strftime("%H:%M") if event.event_time.present?
-    details << event.place if event.place.present?
-
-    note = event.note.to_s.squish
-    details << note.truncate(60) if note.present?
-    details.join(" / ")
+    "#{event.title.to_s.squish.truncate(50)}を会議中"
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@ ja:
   app:
     name: "ごはん会議"
     title: "ごはん会議"
-    description: "みんなでごはんのお店を相談しながら、イベント参加や候補比較を楽しく進められるアプリです。"
+    description: "お店選びを、もっと楽しく"
   services:
     shop_ogp_image_fetcher:
       blank_url: "URLを入力してください"


### PR DESCRIPTION
OGPの文言を調整した。

## 実装内容
- 動的OGPのタイトルを日時ベースに変更
- 動的OGPの説明文をイベント名ベースに変更
- 静的OGPの説明文を「お店選びを、もっと楽しく」に統一

## 動作確認
- [x] 共有URLで動的OGPが想定どおり表示される
- [x] トップページで静的OGPが想定どおり表示される
- [x] LINEで共有時に最新の文言が表示される

## 補足
- LINE確認時はキャッシュ回避のためクエリ付きURLで確認する

Closes #57