### PR TITLE
feat: 独自ドメインの許可ホストを追加する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,6 +94,8 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
+  config.hosts << "gohankaigi.com"
+  config.hosts << "www.gohankaigi.com"
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要
独自ドメイン対応に向けて、production で許可するホストに `gohankaigi.com` と `www.gohankaigi.com` を追加した。

## 実装内容
- `config/environments/production.rb` に `config.hosts` を追加
- `gohankaigi.com` を許可
- `www.gohankaigi.com` を許可

## 動作確認
- [x] Render でデプロイが成功する
- [x] `onrender.com` 側の既存動作に影響がない
- [x] 独自ドメイン反映後に `gohankaigi.com` でアクセスできる
- [x] 独自ドメイン反映後に `www.gohankaigi.com` でアクセスできる

## 補足
- Render 側の独自ドメイン承認待ちのため、現時点では Rails 側の準備のみ
- ドメイン反映後に実アクセス確認を行う