### PR TITLE
feat: Render標準URLを許可ホストに追加する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,6 +96,7 @@ Rails.application.configure do
   # ]
   config.hosts << "gohankaigi.com"
   config.hosts << "www.gohankaigi.com"
+  config.hosts << "gohan-kaigi.onrender.com"
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要
Render の標準URL `gohan-kaigi.onrender.com` からのアクセスが Rails にブロックされていたため、production で許可するホストに追加した。

## 実装内容
- `config/environments/production.rb` の `config.hosts` に `gohan-kaigi.onrender.com` を追加

## 動作確認
- [x] Render でデプロイが成功する
- [x] `gohan-kaigi.onrender.com` でブロックされずアクセスできる
- [x] 既存の独自ドメイン設定に影響がない

## 補足
- 独自ドメイン用ホスト追加後、Render 標準URLが `Blocked hosts` になったため追加対応
- 独自ドメイン反映待ちの間も、Render 標準URLで確認できるようにするための修正
