### PR TITLE
feat: スマホ表示のレイアウトを調整する

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,11 +1,11 @@
 <div class="min-h-[calc(100vh-64px)] bg-gradient-to-b from-[#fbf6ef] via-[#f8f1e7] to-[#f5ede2] px-4 py-8 sm:py-12">
   <div class="max-w-6xl mx-auto space-y-8">
     <section class="relative overflow-hidden rounded-3xl text-white p-7 sm:p-10 lg:p-12 min-h-[320px] lg:min-h-[360px] shadow-xl shadow-orange-200/30">
-      <div class="absolute inset-0 scale-[1.12] bg-cover bg-[50%_22%] bg-no-repeat" style="background-image: url('<%= asset_path('dashboard.png') %>');"></div>
+      <div class="absolute inset-0 scale-[1.0] bg-cover bg-[72%_46%] bg-no-repeat sm:scale-[1.12] sm:bg-[50%_22%]" style="background-image: url('<%= asset_path('dashboard.png') %>');"></div>
       <div class="absolute inset-0 bg-gradient-to-r from-black/55 via-black/30 to-black/15"></div>
       <div class="absolute inset-0 bg-gradient-to-t from-amber-950/30 via-transparent to-white/10"></div>
 
-      <div class="relative z-10 max-w-2xl">
+      <div class="relative z-10 max-w-2xl pt-8 sm:pt-0">
         <p class="inline-flex items-center gap-2 rounded-full bg-white/20 backdrop-blur-sm px-3 py-1 text-xs font-bold tracking-widest uppercase">
           <span class="material-symbols-outlined text-sm">dashboard</span>
           <%= t("views.dashboard.hero_badge") %>
@@ -14,7 +14,7 @@
           <%= t("views.dashboard.welcome") %>
           <span><%= current_user.name %></span><%= t("views.shared.header.user_suffix") %>
         </h1>
-        <p class="mt-3 text-white/95 text-base sm:text-lg [text-shadow:0_1px_8px_rgba(0,0,0,0.35)]">
+        <p class="mt-2 sm:mt-3 text-white/95 text-base sm:text-lg [text-shadow:0_1px_8px_rgba(0,0,0,0.35)]">
           <%= t("views.dashboard.message") %>
         </p>
       </div>

--- a/app/views/shop_logs/index.html.erb
+++ b/app/views/shop_logs/index.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl space-y-8 sm:space-y-10">
     <section class="relative min-h-[320px] overflow-hidden rounded-[2rem] border border-[#d7cdbc] px-6 py-14 shadow-xl shadow-stone-200/30 sm:px-10 sm:py-16">
       <%= image_tag "shop_log.png",
-            class: "absolute inset-0 h-full w-full scale-[1.18] object-cover object-[46%_40%]",
+            class: "absolute inset-0 h-full w-full scale-[1.08] object-cover object-[50%_38%] sm:scale-[1.18] sm:object-[46%_40%]",
             alt: "" %>
 
       <div class="relative z-10 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -16,8 +16,9 @@
           <%= t("views.static_pages.top.hero.badge") %>
         </p>
 
-        <h1 class="brand-title text-[2.85rem] sm:text-[3.7rem] lg:text-[4.5rem] font-black tracking-tight leading-[1.08] text-neutral-700">
-          <%= t("views.static_pages.top.hero.title_line1") %><br>
+        <h1 class="brand-title text-[2.45rem] sm:text-[3.7rem] lg:text-[4.5rem] font-black tracking-tight leading-[1.08] text-neutral-700">
+          <span class="sm:hidden"><%= t("views.static_pages.top.hero.title_line1_mobile") %></span>
+          <span class="hidden sm:inline"><%= t("views.static_pages.top.hero.title_line1") %></span><br>
           <span class="text-[#e3744b]"><%= t("views.static_pages.top.hero.title_highlight") %></span>
         </h1>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,7 +26,7 @@ ja:
       header:
         user_suffix: "さん"
         menu:
-          top: "トップ"
+          top: "ダッシュボード"
           new_event: "イベント作成"
           events: "イベント一覧"
           shop_logs: "お店ログ"
@@ -341,6 +341,7 @@ ja:
           badge: "お店選びを、もっと楽しく"
           title: "ごはん会議"
           title_line1: "みんなで決める"
+          title_line1_mobile: "みんなで決める"
           title_highlight: "ごはん会議"
           subtitle: "みんなの「行きたい」を、わかりやすく。"
           description_line1: "候補をまとめて、いいねで見える化。"


### PR DESCRIPTION
## 概要
スマホ縦画面で気になっていたレイアウト崩れや見え方を調整した。

## 実装内容
- トップページの見出し改行をスマホ向けに調整
- ダッシュボードのヒーロー画像位置とテキスト余白をスマホ向けに調整
- お店ログのヒーロー画像位置をスマホ向けに調整
- ハンバーガーメニューの「トップ」表記を「ダッシュボード」に変更

## 動作確認
- [x] トップページの見出しがスマホ幅で不自然に折れない
- [x] ダッシュボードのヒーロー画像がスマホ幅で自然に見える
- [x] お店ログのヒーロー画像がスマホ幅で自然に見える
- [x] ハンバーガーメニューの文言が「ダッシュボード」になっている

## 補足
- 主にスマホ縦画面を対象に調整
- `sm:` 以上では既存の見え方をできるだけ維持する方針

Closes #72
