### PR TITLE
feat: GitHub ActionsのCIを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test-setup:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: myapp_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres -d myapp_test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:password@localhost:5432/myapp_test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Prepare test database
+        run: bin/rails db:prepare


### PR DESCRIPTION
## 概要
GitHub Actions を導入し、pull_request / main への push 時に test 環境のセットアップが自動実行されるようにした。
今後 RSpec を継続して安全に回せるように、まずは CI の土台を整えた。

## 実装内容
- `.github/workflows/ci.yml` を追加
- `pull_request` / `main` push で CI が動くように設定
- GitHub Actions の `services: postgres` で PostgreSQL を起動
- `ruby/setup-ruby` で Ruby をセットアップ
- `RAILS_ENV=test` と `DATABASE_URL` を設定
- `bin/rails db:prepare` で test DB 準備を実行

## 動作確認
- [x] pull_request で GitHub Actions が自動実行される
- [x] `main` への push で GitHub Actions が自動実行される
- [x] PostgreSQL service が起動する
- [x] `bin/rails db:prepare` が成功する
- [x] DB 接続エラーなどで落ちない

## 補足
- 今回は RSpec 導入前のため、`bundle exec rspec` はまだ含めていない
- まずは test DB 準備まで通る最小 CI を追加した
- 次の issue で RSpec 導入と CI へのテスト実行追加を進める

Closes #66 
