### PR TITLE
chore: Instagram取得調査用のログを追加する

### DIFF
--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -13,6 +13,7 @@ class ShopNameFetcher
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_blank_url")) if @url.blank?
 
     response = Faraday.get(@url)
+    log_instagram_response(response.body, response.status) if instagram_url?
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed")) unless response.success?
 
     candidate_name = extract_name(response.body)
@@ -34,5 +35,26 @@ class ShopNameFetcher
     return og_title if og_title.present?
 
     document.at_css("title")&.text&.strip
+  end
+
+  def instagram_url?
+    uri = URI.parse(@url)
+    uri.host.to_s.downcase.include?("instagram.com")
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def log_instagram_response(body, status)
+    document = Nokogiri::HTML(body)
+
+    Rails.logger.info(
+      "[Instagram ShopNameFetcher] " \
+      "url=#{@url} " \
+      "status=#{status} " \
+      "title=#{document.at_css("title")&.text&.squish.inspect} " \
+      "og_title=#{document.at_css('meta[property=\"og:title\"]')&.[]("content")&.squish.inspect} " \
+      "og_image=#{document.at_css('meta[property=\"og:image\"]')&.[]("content")&.squish.inspect} " \
+      "body_head=#{body.to_s.first(500).inspect}"
+    )
   end
 end

--- a/app/services/shop_ogp_image_fetcher.rb
+++ b/app/services/shop_ogp_image_fetcher.rb
@@ -13,6 +13,7 @@ class ShopOgpImageFetcher
     return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.blank_url")) if @url.blank?
 
     response = Faraday.get(@url)
+    log_instagram_response(response.body, response.status) if instagram_url?
     return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.request_failed")) unless response.success?
 
     image_url = extract_image_url(response.body)
@@ -35,5 +36,26 @@ class ShopOgpImageFetcher
     URI.join(@url, raw_image_url).to_s
   rescue URI::InvalidURIError
     nil
+  end
+
+  def instagram_url?
+    uri = URI.parse(@url)
+    uri.host.to_s.downcase.include?("instagram.com")
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def log_instagram_response(body, status)
+    document = Nokogiri::HTML(body)
+
+    Rails.logger.info(
+      "[Instagram ShopOgpImageFetcher] " \
+      "url=#{@url} " \
+      "status=#{status} " \
+      "title=#{document.at_css("title")&.text&.squish.inspect} " \
+      "og_title=#{document.at_css('meta[property=\"og:title\"]')&.[]("content")&.squish.inspect} " \
+      "og_image=#{document.at_css('meta[property=\"og:image\"]')&.[]("content")&.squish.inspect} " \
+      "body_head=#{body.to_s.first(500).inspect}"
+    )
   end
 end


### PR DESCRIPTION
## 概要
本番環境で Instagram URL の店名取得 / OGP画像取得が失敗する原因を切り分けるため、一時的なログ出力を追加した。

## 実装内容
- `ShopNameFetcher` に Instagram URL 用の一時ログを追加
- `ShopOgpImageFetcher` に Instagram URL 用の一時ログを追加
- 本番ログで `status` / `title` / `og:title` / `og:image` / `body_head` を確認できるようにした

## 動作確認
- [ ] 本番で Instagram URL を入力したときに Render Logs にログが出る
- [ ] `ShopNameFetcher` 側のログを確認できる
- [ ] `ShopOgpImageFetcher` 側のログを確認できる
- [ ] 本番で返っている `title` / `og:title` / `og:image` の内容を確認できる

## 補足
- 今回の変更は本番調査用の一時ログ
- 原因確認後に削除する前提
- 恒久対応はログ確認後に別途行う