### PR TITLE
chore: Instagram調査ログのセレクタを修正する

### DIFF
--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -48,14 +48,16 @@ class ShopNameFetcher
 
   def log_instagram_response(body, status)
     document = Nokogiri::HTML(body)
+    og_title_selector = 'meta[property="og:title"]'
+    og_image_selector = 'meta[property="og:image"]'
 
     Rails.logger.info(
       "[Instagram ShopNameFetcher] " \
       "url=#{@url} " \
       "status=#{status} " \
       "title=#{document.at_css("title")&.text&.squish.inspect} " \
-      "og_title=#{document.at_css('meta[property=\"og:title\"]')&.[]("content")&.squish.inspect} " \
-      "og_image=#{document.at_css('meta[property=\"og:image\"]')&.[]("content")&.squish.inspect} " \
+      "og_title=#{document.at_css(og_title_selector)&.[]("content")&.squish.inspect} " \
+      "og_image=#{document.at_css(og_image_selector)&.[]("content")&.squish.inspect} " \
       "body_head=#{body.to_s.first(500).inspect}"
     )
   end

--- a/app/services/shop_ogp_image_fetcher.rb
+++ b/app/services/shop_ogp_image_fetcher.rb
@@ -49,14 +49,16 @@ class ShopOgpImageFetcher
 
   def log_instagram_response(body, status)
     document = Nokogiri::HTML(body)
+    og_title_selector = 'meta[property="og:title"]'
+    og_image_selector = 'meta[property="og:image"]'
 
     Rails.logger.info(
       "[Instagram ShopOgpImageFetcher] " \
       "url=#{@url} " \
       "status=#{status} " \
       "title=#{document.at_css("title")&.text&.squish.inspect} " \
-      "og_title=#{document.at_css('meta[property=\"og:title\"]')&.[]("content")&.squish.inspect} " \
-      "og_image=#{document.at_css('meta[property=\"og:image\"]')&.[]("content")&.squish.inspect} " \
+      "og_title=#{document.at_css(og_title_selector)&.[]("content")&.squish.inspect} " \
+      "og_image=#{document.at_css(og_image_selector)&.[]("content")&.squish.inspect} " \
       "body_head=#{body.to_s.first(500).inspect}"
     )
   end


### PR DESCRIPTION
## 概要
Instagram URL の本番取得調査用に追加した一時ログで `Nokogiri::CSS::SyntaxError` が発生していたため、ログ用 selector の記法を修正した。

## 実装内容
- `ShopNameFetcher` の一時ログで使う `at_css` selector を修正
- `ShopOgpImageFetcher` の一時ログで使う `at_css` selector を修正
- 本番で `title` / `og:title` / `og:image` の確認ログを正常に出せるようにした

## 動作確認
- [ ] 本番で Instagram URL を入力したときに `CSS::SyntaxError` が出ない
- [ ] Render Logs に `ShopNameFetcher` 側のログが出る
- [ ] 必要なら `ShopOgpImageFetcher` 側のログも確認できる
- [ ] 本番レスポンスの `title` / `og:title` / `og:image` を確認できる

## 補足
- 今回の変更は本番調査用の一時ログ修正
- 原因確認後はログ削除を行う前提
- 恒久対応はログ確認後に別途行う
