### PR TITLE
chore: Instagram調査ログにlocationを追加する

### DIFF
--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -13,7 +13,7 @@ class ShopNameFetcher
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_blank_url")) if @url.blank?
 
     response = Faraday.get(@url)
-    log_instagram_response(response.body, response.status) if instagram_url?
+    log_instagram_response(response) if instagram_url?
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed")) unless response.success?
 
     candidate_name = extract_name(response.body)
@@ -46,19 +46,20 @@ class ShopNameFetcher
     false
   end
 
-  def log_instagram_response(body, status)
-    document = Nokogiri::HTML(body)
+  def log_instagram_response(response)
+    document = Nokogiri::HTML(response.body)
     og_title_selector = 'meta[property="og:title"]'
     og_image_selector = 'meta[property="og:image"]'
 
     Rails.logger.info(
       "[Instagram ShopNameFetcher] " \
       "url=#{@url} " \
-      "status=#{status} " \
+      "status=#{response.status} " \
+      "location=#{response.headers["location"].inspect} " \
       "title=#{document.at_css("title")&.text&.squish.inspect} " \
       "og_title=#{document.at_css(og_title_selector)&.[]("content")&.squish.inspect} " \
       "og_image=#{document.at_css(og_image_selector)&.[]("content")&.squish.inspect} " \
-      "body_head=#{body.to_s.first(500).inspect}"
+      "body_head=#{response.body.to_s.first(500).inspect}"
     )
   end
 


### PR DESCRIPTION
## 概要
本番環境で Instagram URL に対して `status=302` が返っていることを確認できたため、リダイレクト先を切り分けるために一時ログへ `location` を追加した。

## 実装内容
- `ShopNameFetcher` の一時ログに `response.headers["location"]` を追加
- 本番ログで 302 の転送先を確認できるようにした

## 動作確認
- [ ] 本番で Instagram URL を入力したときに `location` がログに出る
- [ ] 302 の転送先を確認できる
- [ ] 次の恒久対応判断に必要な情報が取得できる

## 補足
- 今回の変更は本番調査用の一時ログ
- 原因確認後は削除する前提
- 恒久対応はログ確認後に別途行う