### PR TITLE
chore: Instagram調査用にリダイレクト追従を追加する

### DIFF
--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -1,5 +1,6 @@
 class ShopNameFetcher
   Result = Struct.new(:name, :error, keyword_init: true)
+  MAX_REDIRECTS = 3
 
   def self.call(url)
     new(url).call
@@ -12,7 +13,7 @@ class ShopNameFetcher
   def call
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_blank_url")) if @url.blank?
 
-    response = Faraday.get(@url)
+    response = fetch_response(@url)
     log_instagram_response(response) if instagram_url?
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed")) unless response.success?
 
@@ -39,6 +40,22 @@ class ShopNameFetcher
     document.at_css("title")&.text&.strip
   end
 
+  def fetch_response(url, redirect_count = 0)
+    response = Faraday.get(url)
+    return response unless redirect_response?(response)
+    return response if redirect_count >= MAX_REDIRECTS
+
+    location = response.headers["location"]
+    return response if location.blank?
+
+    next_url = URI.join(url, location).to_s
+    fetch_response(next_url, redirect_count + 1)
+  end
+
+  def redirect_response?(response)
+    response.status.to_i >= 300 && response.status.to_i < 400
+  end
+
   def instagram_url?
     uri = URI.parse(@url)
     uri.host.to_s.downcase.include?("instagram.com")
@@ -54,6 +71,7 @@ class ShopNameFetcher
     Rails.logger.info(
       "[Instagram ShopNameFetcher] " \
       "url=#{@url} " \
+      "final_url=#{response.env.url} " \
       "status=#{response.status} " \
       "location=#{response.headers["location"].inspect} " \
       "title=#{document.at_css("title")&.text&.squish.inspect} " \


### PR DESCRIPTION
## 概要
本番環境で Instagram URL に対して `302` が返っていることを確認できたため、最終的な遷移先を確認するために `ShopNameFetcher` にリダイレクト追従を追加した。

## 実装内容
- `ShopNameFetcher` に `fetch_response` を追加
- 300番台レスポンス時に `location` をたどる処理を追加
- 最大3回までリダイレクトを追従するようにした
- 調査ログに `final_url` を追加

## 動作確認
- [ ] 本番で Instagram URL を入力したときにリダイレクトを追従する
- [ ] Render Logs に `final_url` が出る
- [ ] 最終的な遷移先を確認できる
- [ ] `title` / `og:title` / `og:image` の確認材料を取得できる

## 補足
- 今回の変更は本番調査用
- まずは `ShopNameFetcher` のみ対応
- 原因確認後に恒久対応を別途判断する
