### PR TITLE
chore: SNS URL取得失敗時の案内を追加する

### DIFF
--- a/app/services/shop_name_fetcher.rb
+++ b/app/services/shop_name_fetcher.rb
@@ -1,6 +1,5 @@
 class ShopNameFetcher
   Result = Struct.new(:name, :error, keyword_init: true)
-  MAX_REDIRECTS = 3
 
   def self.call(url)
     new(url).call
@@ -13,19 +12,16 @@ class ShopNameFetcher
   def call
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_blank_url")) if @url.blank?
 
-    response = fetch_response(@url)
-    log_instagram_response(response) if instagram_url?
+    response = Faraday.get(@url)
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed")) unless response.success?
 
     candidate_name = extract_name(response.body)
     return Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_not_found")) if candidate_name.blank?
 
     Result.new(name: candidate_name, error: nil)
-  rescue Faraday::Error => e
-    log_instagram_error(e) if instagram_url?
+  rescue Faraday::Error
     Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_request_failed"))
-  rescue StandardError => e
-    log_instagram_error(e) if instagram_url?
+  rescue StandardError
     Result.new(name: nil, error: I18n.t("views.shops.form.fetch_name_unexpected_error"))
   end
 
@@ -38,55 +34,5 @@ class ShopNameFetcher
     return og_title if og_title.present?
 
     document.at_css("title")&.text&.strip
-  end
-
-  def fetch_response(url, redirect_count = 0)
-    response = Faraday.get(url)
-    return response unless redirect_response?(response)
-    return response if redirect_count >= MAX_REDIRECTS
-
-    location = response.headers["location"]
-    return response if location.blank?
-
-    next_url = URI.join(url, location).to_s
-    fetch_response(next_url, redirect_count + 1)
-  end
-
-  def redirect_response?(response)
-    response.status.to_i >= 300 && response.status.to_i < 400
-  end
-
-  def instagram_url?
-    uri = URI.parse(@url)
-    uri.host.to_s.downcase.include?("instagram.com")
-  rescue URI::InvalidURIError
-    false
-  end
-
-  def log_instagram_response(response)
-    document = Nokogiri::HTML(response.body)
-    og_title_selector = 'meta[property="og:title"]'
-    og_image_selector = 'meta[property="og:image"]'
-
-    Rails.logger.info(
-      "[Instagram ShopNameFetcher] " \
-      "url=#{@url} " \
-      "final_url=#{response.env.url} " \
-      "status=#{response.status} " \
-      "location=#{response.headers["location"].inspect} " \
-      "title=#{document.at_css("title")&.text&.squish.inspect} " \
-      "og_title=#{document.at_css(og_title_selector)&.[]("content")&.squish.inspect} " \
-      "og_image=#{document.at_css(og_image_selector)&.[]("content")&.squish.inspect} " \
-      "body_head=#{response.body.to_s.first(500).inspect}"
-    )
-  end
-
-  def log_instagram_error(error)
-    Rails.logger.info(
-      "[Instagram ShopNameFetcher Error] " \
-      "url=#{@url} " \
-      "error_class=#{error.class} " \
-      "message=#{error.message.inspect}"
-    )
   end
 end

--- a/app/services/shop_ogp_image_fetcher.rb
+++ b/app/services/shop_ogp_image_fetcher.rb
@@ -13,18 +13,15 @@ class ShopOgpImageFetcher
     return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.blank_url")) if @url.blank?
 
     response = Faraday.get(@url)
-    log_instagram_response(response.body, response.status) if instagram_url?
     return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.request_failed")) unless response.success?
 
     image_url = extract_image_url(response.body)
     return Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.not_found")) if image_url.blank?
 
     Result.new(image_url:, error: nil)
-  rescue Faraday::Error => e
-    log_instagram_error(e) if instagram_url?
+  rescue Faraday::Error
     Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.request_failed"))
-  rescue StandardError => e
-    log_instagram_error(e) if instagram_url?
+  rescue StandardError
     Result.new(image_url: nil, error: I18n.t("services.shop_ogp_image_fetcher.unexpected_error"))
   end
 
@@ -38,37 +35,5 @@ class ShopOgpImageFetcher
     URI.join(@url, raw_image_url).to_s
   rescue URI::InvalidURIError
     nil
-  end
-
-  def instagram_url?
-    uri = URI.parse(@url)
-    uri.host.to_s.downcase.include?("instagram.com")
-  rescue URI::InvalidURIError
-    false
-  end
-
-  def log_instagram_response(body, status)
-    document = Nokogiri::HTML(body)
-    og_title_selector = 'meta[property="og:title"]'
-    og_image_selector = 'meta[property="og:image"]'
-
-    Rails.logger.info(
-      "[Instagram ShopOgpImageFetcher] " \
-      "url=#{@url} " \
-      "status=#{status} " \
-      "title=#{document.at_css("title")&.text&.squish.inspect} " \
-      "og_title=#{document.at_css(og_title_selector)&.[]("content")&.squish.inspect} " \
-      "og_image=#{document.at_css(og_image_selector)&.[]("content")&.squish.inspect} " \
-      "body_head=#{body.to_s.first(500).inspect}"
-    )
-  end
-
-  def log_instagram_error(error)
-    Rails.logger.info(
-      "[Instagram ShopOgpImageFetcher Error] " \
-      "url=#{@url} " \
-      "error_class=#{error.class} " \
-      "message=#{error.message.inspect}"
-    )
   end
 end

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -57,6 +57,10 @@
                   </p>
                 </div>
 
+                <p class="mt-2 text-sm text-base-content/50">
+                  <%= t("views.shops.form.fetch_name_sns_notice") %>
+                </p>
+
                 <p class="mt-2 hidden text-sm text-base-content/50" data-shop-name-fetch-target="message">
                   <%= t("views.shops.form.fetch_name_idle") %>
                 </p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -238,6 +238,7 @@ ja:
         fetch_name_button: "URLから店名を取得"
         fetch_name_loading: "取得中..."
         fetch_name_hint: "取得後も手入力で修正できます"
+        fetch_name_sns_notice: "Instagram・X などのSNS URLは、ページ情報を自動取得できない場合があります。その場合は店名を入力してください"
         fetch_name_idle: "URLを入力してから店名取得ボタンを押してください"
         fetch_name_blank_url: "URLを入力してください"
         fetch_name_request_failed: "ページ情報を取得できませんでした"


### PR DESCRIPTION
## 概要
Instagram・X などの SNS URL はページ情報を自動取得できない場合があるため、店舗登録フォームに案内文を追加した。
あわせて、Instagram 調査用に追加していた一時ログやリダイレクト追従コードを整理した。

## 実装内容
- `ShopNameFetcher` から調査用ログを削除
- `ShopNameFetcher` から調査用のリダイレクト追従を削除
- `ShopOgpImageFetcher` から調査用ログを削除
- 店舗登録フォームに SNS URL 用の注意書きを追加
- 注意書き文言を `ja.yml` に追加

## 動作確認
- [ ] 店舗登録フォームに注意書きが表示される
- [ ] Instagram・X の URL が自動取得失敗しても店名手入力で登録を進められる
- [ ] 調査用ログが本番コードから除かれている

## 補足
- 今回は SNS URL の自動取得成功率を改善する対応ではない
- リリース前対応として、失敗時でも分かりやすく進められる UX を優先した
- 画像手動追加機能は今回は対象外