### PR TITLE
Feat: モデルスペックを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ group :development do
 end
 
 group :test do
+  gem "simplecov", require: false
+
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       devise (>= 5.0.0)
       rails-i18n
     diff-lcs (1.6.2)
+    docile (1.4.1)
     drb (2.2.3)
     erb (6.0.1)
     erubi (1.13.1)
@@ -375,6 +376,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -452,6 +459,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov
   sprockets-rails
   stimulus-rails
   turbo-rails
@@ -491,6 +499,7 @@ CHECKSUMS
   devise (5.0.2) sha256=254330c9290e612ad9681e8a18c96aa21fb95bc391af936b84480965444bb0b6
   devise-i18n (1.16.0) sha256=a33306f90f317cfe92753a000064e3ba9dec3cab2d5d01ef40d30f4b6e24e753
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
@@ -590,6 +599,9 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.39.0) sha256=984a1e63d39472eaf286bac3c6f1822fa7eea6eed9c07a66ce7b3bc5417ba826
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e

--- a/spec/factories/event_participants.rb
+++ b/spec/factories/event_participants.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :event_participant do
+    association :event
+    association :user
+  end
+end

--- a/spec/factories/event_preferences.rb
+++ b/spec/factories/event_preferences.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :event_preference do
+    association :event
+    association :user
+    dislike_foods { "none" }
+    budget { 3 }
+    content { "preference note" }
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :event do
+    association :user
+    sequence(:title) { |n| "event_#{n}" }
+    event_date { Date.current }
+    event_time { Time.zone.parse("18:00") }
+    place { "tokyo" }
+    note { "event note" }
+    unique_url { nil }
+  end
+end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :like do
+    association :shop
+    association :user
+  end
+end

--- a/spec/factories/shops.rb
+++ b/spec/factories/shops.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :shop do
+    association :event
+    user { event.user }
+    sequence(:name) { |n| "shop_#{n}" }
+    url { "https://example.com/shops/1" }
+    address { "tokyo" }
+    memo { "shop memo" }
+    log_note { "log note" }
+    ogp_image_url { "https://example.com/shop.png" }
+    place_id { nil }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:name) { |n| "test_user_#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password123" }
+    password_confirmation { "password123" }
+  end
+end

--- a/spec/models/event_participant_spec.rb
+++ b/spec/models/event_participant_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe EventParticipant, type: :model do
+  describe "バリデーション" do
+    it "有効なfactoryを持つこと" do
+      expect(build(:event_participant)).to be_valid
+    end
+
+    it "同じuserとeventの組み合わせは重複できないこと" do
+      event_participant = create(:event_participant)
+      duplicate = build(:event_participant, event: event_participant.event, user: event_participant.user)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:user_id]).to be_present
+    end
+
+    it "eventがないと無効になること" do
+      event_participant = build(:event_participant, event: nil)
+
+      expect(event_participant).not_to be_valid
+      expect(event_participant.errors[:event]).to be_present
+    end
+
+    it "userがないと無効になること" do
+      event_participant = build(:event_participant, user: nil)
+
+      expect(event_participant).not_to be_valid
+      expect(event_participant.errors[:user]).to be_present
+    end
+  end
+end

--- a/spec/models/event_preference_spec.rb
+++ b/spec/models/event_preference_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe EventPreference, type: :model do
+  describe "バリデーション" do
+    it "有効なfactoryを持つこと" do
+      expect(build(:event_preference)).to be_valid
+    end
+
+    it "同じuserとeventの組み合わせは重複できないこと" do
+      event_preference = create(:event_preference)
+      duplicate = build(:event_preference, event: event_preference.event, user: event_preference.user)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:user_id]).to be_present
+    end
+
+    it "eventがないと無効になること" do
+      event_preference = build(:event_preference, event: nil)
+
+      expect(event_preference).not_to be_valid
+      expect(event_preference.errors[:event]).to be_present
+    end
+
+    it "userがないと無効になること" do
+      event_preference = build(:event_preference, user: nil)
+
+      expect(event_preference).not_to be_valid
+      expect(event_preference.errors[:user]).to be_present
+    end
+  end
+
+  describe "#budget_label" do
+    it "budgetが1のとき対応する文言を返すこと" do
+      event_preference = build(:event_preference, budget: 1)
+
+      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.one"))
+    end
+
+    it "budgetが2のとき対応する文言を返すこと" do
+      event_preference = build(:event_preference, budget: 2)
+
+      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.two"))
+    end
+
+    it "budgetが3のとき対応する文言を返すこと" do
+      event_preference = build(:event_preference, budget: 3)
+
+      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.three"))
+    end
+
+    it "budgetが4のとき対応する文言を返すこと" do
+      event_preference = build(:event_preference, budget: 4)
+
+      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.four"))
+    end
+
+    it "budgetが5のとき対応する文言を返すこと" do
+      event_preference = build(:event_preference, budget: 5)
+
+      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.five"))
+    end
+
+    it "想定外の値なら未設定文言を返すこと" do
+      event_preference = build(:event_preference, budget: nil)
+
+      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.unset"))
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe Event, type: :model do
+  describe "バリデーション" do
+    it "有効なfactoryを持つこと" do
+      expect(build(:event)).to be_valid
+    end
+
+    it "titleが空だと無効になること" do
+      event = build(:event, title: nil)
+
+      expect(event).not_to be_valid
+      expect(event.errors[:title]).to be_present
+    end
+
+    it "event_dateが空だと無効になること" do
+      event = build(:event, event_date: nil)
+
+      expect(event).not_to be_valid
+      expect(event.errors[:event_date]).to be_present
+    end
+
+    it "unique_urlが重複すると無効になること" do
+      create(:event, unique_url: "same-url")
+      event = build(:event, unique_url: "same-url")
+
+      expect(event).not_to be_valid
+      expect(event.errors[:unique_url]).to be_present
+    end
+
+    it "noteが1000文字以内なら有効なこと" do
+      event = build(:event, note: "a" * 1000)
+
+      expect(event).to be_valid
+    end
+
+    it "noteが1001文字以上だと無効になること" do
+      event = build(:event, note: "a" * 1001)
+
+      expect(event).not_to be_valid
+      expect(event.errors[:note]).to be_present
+    end
+
+    it "titleが255文字以内なら有効なこと" do
+      event = build(:event, title: "a" * 255)
+
+      expect(event).to be_valid
+    end
+
+    it "titleが256文字以上だと無効になること" do
+      event = build(:event, title: "a" * 256)
+
+      expect(event).not_to be_valid
+      expect(event.errors[:title]).to be_present
+    end
+
+    it "unique_urlが255文字以内なら有効なこと" do
+      event = build(:event, unique_url: "a" * 255)
+
+      expect(event).to be_valid
+    end
+
+    it "unique_urlが256文字以上だと無効になること" do
+      event = build(:event, unique_url: "a" * 256)
+
+      expect(event).not_to be_valid
+      expect(event.errors[:unique_url]).to be_present
+    end
+
+    it "noteが空でも有効なこと" do
+      event = build(:event, note: "")
+
+      expect(event).to be_valid
+    end
+  end
+
+  describe "関連" do
+    it "participantsから参加者を参照できること" do
+      event = create(:event)
+      user = create(:user)
+      create(:event_participant, event: event, user: user)
+
+      expect(event.participants).to include(user)
+    end
+  end
+
+  describe "コールバック" do
+    it "作成時にunique_urlを自動生成すること" do
+      event = create(:event, unique_url: nil)
+
+      expect(event.unique_url).to be_present
+    end
+
+    it "unique_urlがある場合はその値を維持すること" do
+      event = create(:event, unique_url: "custom-url")
+
+      expect(event.unique_url).to eq("custom-url")
+    end
+  end
+
+  describe "dependent: :destroy" do
+    it "関連するレコードも削除すること" do
+      event = create(:event)
+      participant = create(:event_participant, event: event)
+      shop = create(:shop, event: event)
+      preference = create(:event_preference, event: event)
+
+      expect { event.destroy }
+        .to change(EventParticipant, :count).by(-1)
+        .and change(Shop, :count).by(-1)
+        .and change(EventPreference, :count).by(-1)
+    end
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Like, type: :model do
+  describe "バリデーション" do
+    it "有効なfactoryを持つこと" do
+      expect(build(:like)).to be_valid
+    end
+
+    it "shopがないと無効になること" do
+      like = build(:like, shop: nil)
+
+      expect(like).not_to be_valid
+      expect(like.errors[:shop]).to be_present
+    end
+
+    it "userがないと無効になること" do
+      like = build(:like, user: nil)
+
+      expect(like).not_to be_valid
+      expect(like.errors[:user]).to be_present
+    end
+  end
+
+  describe "counter_cache" do
+    it "作成時にshopのlikes_countが増えること" do
+      shop = create(:shop)
+
+      expect { create(:like, shop: shop) }
+        .to change { shop.reload.likes_count }.by(1)
+    end
+
+    it "削除時にshopのlikes_countが減ること" do
+      like = create(:like)
+
+      expect { like.destroy }
+        .to change { like.shop.reload.likes_count }.by(-1)
+    end
+  end
+
+  describe "整合性" do
+    it "同じuserとshopの組み合わせはDBレベルで重複できないこと" do
+      like = create(:like)
+
+      expect {
+        Like.create!(shop: like.shop, user: like.user)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end

--- a/spec/models/shop_spec.rb
+++ b/spec/models/shop_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe Shop, type: :model do
+  describe "バリデーション" do
+    it "有効なfactoryを持つこと" do
+      expect(build(:shop)).to be_valid
+    end
+
+    it "nameが空だと無効になること" do
+      shop = build(:shop, name: nil)
+
+      expect(shop).not_to be_valid
+      expect(shop.errors[:name]).to be_present
+    end
+
+    it "log_noteが1000文字以内なら有効なこと" do
+      shop = build(:shop, log_note: "a" * 1000)
+
+      expect(shop).to be_valid
+    end
+
+    it "log_noteが1001文字以上だと無効になること" do
+      shop = build(:shop, log_note: "a" * 1001)
+
+      expect(shop).not_to be_valid
+      expect(shop.errors[:log_note]).to be_present
+    end
+
+    it "eventがないと無効になること" do
+      shop = build(:shop, event: nil, user: build(:user))
+
+      expect(shop).not_to be_valid
+      expect(shop.errors[:event]).to be_present
+    end
+
+    it "userがないと無効になること" do
+      shop = build(:shop, user: nil)
+
+      expect(shop).not_to be_valid
+      expect(shop.errors[:user]).to be_present
+    end
+  end
+
+  describe "関連" do
+    it "liked_usersからいいねしたuserを参照できること" do
+      shop = create(:shop)
+      user = create(:user)
+      create(:like, shop: shop, user: user)
+
+      expect(shop.liked_users).to include(user)
+    end
+
+    it "likes_countの初期値が0であること" do
+      shop = create(:shop)
+
+      expect(shop.likes_count).to eq(0)
+    end
+  end
+
+  describe "dependent: :destroy" do
+    it "関連するlikesを削除すること" do
+      shop = create(:shop)
+      create(:like, shop: shop)
+
+      expect { shop.destroy }.to change(Like, :count).by(-1)
+    end
+  end
+
+  describe "#map_query" do
+    it "event_placeがある場合は店名と結合すること" do
+      shop = build(:shop, name: "coffee")
+
+      expect(shop.map_query("shinjuku")).to eq("coffee shinjuku")
+    end
+
+    it "event_placeがない場合は店名だけ返すこと" do
+      shop = build(:shop, name: "coffee")
+
+      expect(shop.map_query).to eq("coffee")
+    end
+
+    it "店名だけあれば店名を返すこと" do
+      shop = build(:shop, name: "coffee")
+
+      expect(shop.map_query(nil)).to eq("coffee")
+    end
+  end
+
+  describe "#map_embed_url" do
+    it "place_idがある場合はGoogle Maps embed URLを返すこと" do
+      shop = build(:shop, name: "coffee", place_id: "place-123")
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
+
+      expect(shop.map_embed_url("shinjuku")).to eq(
+        "https://www.google.com/maps/embed/v1/place?key=test-key&q=place_id:place-123"
+      )
+    end
+
+    it "place_idがない場合は店名ベースのURLを返すこと" do
+      shop = build(:shop, name: "coffee", place_id: nil)
+
+      expect(shop.map_embed_url("shinjuku")).to eq(
+        "https://www.google.com/maps?q=coffee+shinjuku&output=embed"
+      )
+    end
+  end
+
+  describe "#map_link_url" do
+    it "Google Mapsの検索URLを返すこと" do
+      shop = build(:shop, name: "coffee")
+
+      expect(shop.map_link_url("shinjuku")).to eq(
+        "https://www.google.com/maps/search/?api=1&query=coffee+shinjuku"
+      )
+    end
+  end
+
+  describe "#fetch_place_id" do
+    it "Places APIの先頭idを返すこと" do
+      shop = build(:shop, name: "coffee")
+      response = instance_double(Faraday::Response, body: { places: [ { id: "place-123" } ] }.to_json)
+
+      allow(Faraday).to receive(:post).and_return(response)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
+
+      expect(shop.fetch_place_id("shinjuku")).to eq("place-123")
+    end
+
+    it "候補がない場合はnilを返すこと" do
+      shop = build(:shop, name: "coffee")
+      response = instance_double(Faraday::Response, body: {}.to_json)
+
+      allow(Faraday).to receive(:post).and_return(response)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
+
+      expect(shop.fetch_place_id("shinjuku")).to be_nil
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "バリデーション" do
+    it "有効なfactoryを持つこと" do
+      expect(build(:user)).to be_valid
+    end
+
+    it "nameが空だと無効になること" do
+      user = build(:user, name: nil)
+
+      expect(user).not_to be_valid
+      expect(user.errors[:name]).to be_present
+    end
+
+    it "nameが255文字以内なら有効なこと" do
+      user = build(:user, name: "a" * 255)
+
+      expect(user).to be_valid
+    end
+
+    it "nameが256文字以上だと無効になること" do
+      user = build(:user, name: "a" * 256)
+
+      expect(user).not_to be_valid
+      expect(user.errors[:name]).to be_present
+    end
+
+    it "emailが重複すると無効になること" do
+      create(:user, email: "same@example.com")
+      user = build(:user, email: "same@example.com")
+
+      expect(user).not_to be_valid
+      expect(user.errors[:email]).to be_present
+    end
+  end
+
+  describe "関連" do
+    it "participating_eventsから参加イベントを参照できること" do
+      user = create(:user)
+      event = create(:event)
+      create(:event_participant, user: user, event: event)
+
+      expect(user.participating_events).to include(event)
+    end
+
+    it "liked_shopsからいいねしたshopを参照できること" do
+      user = create(:user)
+      shop = create(:shop)
+      create(:like, user: user, shop: shop)
+
+      expect(user.liked_shops).to include(shop)
+    end
+  end
+
+  describe "dependent: :destroy" do
+    it "関連するレコードも削除すること" do
+      user = create(:user)
+      event = create(:event, user: user)
+      other_event = create(:event)
+      shop = create(:shop, event: other_event, user: user)
+      like_target = create(:shop)
+      create(:like, user: user, shop: like_target)
+      create(:event_preference, user: user, event: other_event)
+      create(:event_participant, user: user, event: other_event)
+
+      expect { user.destroy }
+        .to change(Event, :count).by(-1)
+        .and change(Shop, :count).by(-1)
+        .and change(Like, :count).by(-1)
+        .and change(EventPreference, :count).by(-1)
+        .and change(EventParticipant, :count).by(-1)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require "simplecov"
+SimpleCov.start "rails"
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## 概要
主要モデルと周辺モデルの model spec を追加し、モデル層の重要ルールを RSpec で守れるようにした。
あわせて SimpleCov を導入し、coverage を確認できる状態を整えた。

## 実装内容
- `User` / `Event` / `Shop` の model spec を追加・強化
- `EventParticipant` / `Like` / `EventPreference` の model spec を追加・強化
- factory を追加
- バリデーション、関連、dependent、整合性、主要メソッドを確認
- `SimpleCov` を導入
- RSpec 実行時に coverage レポートを生成できるようにした

## 動作確認
- [x] `bundle exec rspec` が通る
- [x] model spec が 60 examples, 0 failures で通る
- [x] coverage レポートが生成される
- [x] 主要モデルの重要ルールがテストで守られている

## 補足
- 現時点の coverage は model spec 中心の途中経過
- request spec は次 issue で対応予定
- `ShopLog` モデルは現行コードに存在しないため今回の対象外

Closes #58
