### PR TITLE
feat: リクエストスペックを追加する

### DIFF
--- a/app/controllers/shop_logs_controller.rb
+++ b/app/controllers/shop_logs_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ShopLogsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @shops = current_user.shops.includes(:event)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   ]
 
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard", type: :request do
+  describe "GET /dashboard" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      get dashboard_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン時は表示できること" do
+      user = create(:user)
+      sign_in user
+
+      get dashboard_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/event_participants_spec.rb
+++ b/spec/requests/event_participants_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "EventParticipants", type: :request do
+  let(:event) { create(:event) }
+
+  describe "POST /events/:event_id/event_participants" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      post event_event_participants_path(event)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン済みなら参加できること" do
+      user = create(:user)
+      sign_in user
+
+      expect {
+        post event_event_participants_path(event)
+      }.to change(EventParticipant, :count).by(1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "重複参加時は件数が増えないこと" do
+      user = create(:user)
+      create(:event_participant, event: event, user: user)
+      sign_in user
+
+      expect {
+        post event_event_participants_path(event)
+      }.not_to change(EventParticipant, :count)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/requests/event_preferences_spec.rb
+++ b/spec/requests/event_preferences_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe "EventPreferences", type: :request do
+  let(:owner) { create(:user) }
+  let(:participant) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:event) { create(:event, user: owner) }
+
+  before do
+    create(:event_participant, event: event, user: owner)
+    create(:event_participant, event: event, user: participant)
+  end
+
+  describe "POST /events/:event_id/event_preferences" do
+    let(:valid_params) do
+      {
+        event_preference: {
+          dislike_foods: "none",
+          budget: 3,
+          content: "memo"
+        }
+      }
+    end
+
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      post event_event_preferences_path(event), params: valid_params
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "参加者は作成できること" do
+      sign_in participant
+
+      expect {
+        post event_event_preferences_path(event), params: valid_params
+      }.to change(EventPreference, :count).by(1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "既存レコードがある場合は更新され件数は増えないこと" do
+      preference = create(:event_preference, event: event, user: participant, content: "before")
+      sign_in participant
+
+      expect {
+        post event_event_preferences_path(event), params: { event_preference: { content: "after", budget: 4 } }
+      }.not_to change(EventPreference, :count)
+
+      expect(response).to redirect_to(event_path(event))
+      expect(preference.reload.content).to eq("after")
+    end
+
+    it "非参加者は投稿できないこと" do
+      sign_in other_user
+
+      expect {
+        post event_event_preferences_path(event), params: valid_params
+      }.not_to change(EventPreference, :count)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
+  describe "DELETE /events/:event_id/event_preferences/:id" do
+    let!(:preference) { create(:event_preference, event: event, user: participant) }
+
+    it "自分の希望条件を削除できること" do
+      sign_in participant
+
+      expect {
+        delete event_event_preference_path(event, preference)
+      }.to change(EventPreference, :count).by(-1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe "Events", type: :request do
+  describe "GET /events" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      get events_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン時は自分のイベント一覧を表示できること" do
+      user = create(:user)
+      own_event = create(:event, user: user, title: "owned event")
+      create(:event, title: "other event")
+      sign_in user
+
+      get events_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("owned event")
+      expect(response.body).not_to include("other event")
+    end
+
+    it "joinedタブでは参加イベント一覧を表示できること" do
+      user = create(:user)
+      joined_event = create(:event, title: "joined event")
+      own_event = create(:event, user: user, title: "owned event")
+      create(:event_participant, event: joined_event, user: user)
+      sign_in user
+
+      get events_path, params: { tab: "joined" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("joined event")
+      expect(response.body).not_to include("owned event")
+    end
+  end
+
+  describe "GET /events/:id" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      event = create(:event)
+
+      get event_path(event)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン時は詳細を表示できること" do
+      user = create(:user)
+      event = create(:event, title: "event detail")
+      sign_in user
+
+      get event_path(event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("event detail")
+    end
+  end
+
+  describe "GET /events/join/:unique_url" do
+    it "未ログインでも表示できること" do
+      event = create(:event, title: "join event")
+
+      get join_event_path(event.unique_url)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("join event")
+    end
+  end
+
+  describe "POST /events" do
+    let(:valid_params) do
+      {
+        event: {
+          title: "new event",
+          event_date: Date.current,
+          event_time: "18:00",
+          place: "tokyo",
+          note: "note"
+        }
+      }
+    end
+
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      post events_path, params: valid_params
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "有効な値ならイベントと参加レコードを作成すること" do
+      user = create(:user)
+      sign_in user
+
+      expect {
+        post events_path, params: valid_params
+      }.to change(Event, :count).by(1)
+        .and change(EventParticipant, :count).by(1)
+
+      expect(response).to redirect_to(event_path(Event.last))
+    end
+
+    it "不正な値だと作成されず422を返すこと" do
+      user = create(:user)
+      sign_in user
+
+      expect {
+        post events_path, params: { event: valid_params[:event].merge(title: "") }
+      }.not_to change(Event, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PATCH /events/:id" do
+    it "作成者は更新できること" do
+      user = create(:user)
+      event = create(:event, user: user, title: "before")
+      sign_in user
+
+      patch event_path(event), params: { event: { title: "after" } }
+
+      expect(response).to redirect_to(event_path(event))
+      expect(event.reload.title).to eq("after")
+    end
+
+    it "他人は更新できず詳細へ戻されること" do
+      owner = create(:user)
+      other_user = create(:user)
+      event = create(:event, user: owner, title: "before")
+      sign_in other_user
+
+      patch event_path(event), params: { event: { title: "after" } }
+
+      expect(response).to redirect_to(event_path(event))
+      expect(event.reload.title).to eq("before")
+    end
+
+    it "不正な値だと更新されず422を返すこと" do
+      user = create(:user)
+      event = create(:event, user: user, title: "before")
+      sign_in user
+
+      patch event_path(event), params: { event: { title: "" } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(event.reload.title).to eq("before")
+    end
+  end
+
+  describe "DELETE /events/:id" do
+    it "作成者は削除できること" do
+      user = create(:user)
+      event = create(:event, user: user)
+      sign_in user
+
+      expect {
+        delete event_path(event)
+      }.to change(Event, :count).by(-1)
+
+      expect(response).to redirect_to(events_path)
+    end
+
+    it "他人は削除できないこと" do
+      owner = create(:user)
+      other_user = create(:user)
+      event = create(:event, user: owner)
+      sign_in other_user
+
+      expect {
+        delete event_path(event)
+      }.not_to change(Event, :count)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Likes", type: :request do
+  let(:owner) { create(:user) }
+  let(:participant) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:event) { create(:event, user: owner) }
+  let(:shop) { create(:shop, event: event, user: owner) }
+
+  before do
+    create(:event_participant, event: event, user: owner)
+    create(:event_participant, event: event, user: participant)
+  end
+
+  describe "POST /events/:event_id/shops/:shop_id/like" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      post event_shop_like_path(event, shop)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "参加者はいいねできること" do
+      sign_in participant
+
+      expect {
+        post event_shop_like_path(event, shop)
+      }.to change(Like, :count).by(1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "非参加者はいいねできないこと" do
+      sign_in other_user
+
+      expect {
+        post event_shop_like_path(event, shop)
+      }.not_to change(Like, :count)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
+  describe "DELETE /events/:event_id/shops/:shop_id/like" do
+    let!(:like) { create(:like, user: participant, shop: shop) }
+
+    it "参加者はいいね解除できること" do
+      sign_in participant
+
+      expect {
+        delete event_shop_like_path(event, shop)
+      }.to change(Like, :count).by(-1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/requests/shop_logs_spec.rb
+++ b/spec/requests/shop_logs_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "ShopLogs", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:event) { create(:event, user: user) }
+  let!(:shop1) { create(:shop, event: event, user: user, name: "coffee", log_category: "cafe", log_note: "note1") }
+  let!(:shop2) { create(:shop, event: event, user: user, name: "ramen", log_category: "noodle", log_note: "note2", created_at: 1.day.ago) }
+
+  describe "GET /shop_logs" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      get shop_logs_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン時は表示できること" do
+      sign_in user
+
+      get shop_logs_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("coffee")
+      expect(response.body).to include("ramen")
+    end
+
+    it "qで検索できること" do
+      sign_in user
+
+      get shop_logs_path, params: { q: "coffee" }
+
+      expect(response.body).to include("coffee")
+      expect(response.body).not_to include("ramen")
+    end
+
+    it "categoryで絞り込みできること" do
+      sign_in user
+
+      get shop_logs_path, params: { category: "cafe" }
+
+      expect(response.body).to include("coffee")
+      expect(response.body).not_to include("ramen")
+    end
+  end
+
+  describe "GET /shop_logs/autocomplete" do
+    it "未ログイン時はリダイレクトされること" do
+      get shop_logs_autocomplete_path, params: { q: "co" }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "ログイン時は一致する店名配列を返すこと" do
+      sign_in user
+
+      get shop_logs_autocomplete_path, params: { q: "co" }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq([ "coffee" ])
+    end
+  end
+
+  describe "PATCH /shop_logs/:id" do
+    it "自分のshop logを更新できること" do
+      sign_in user
+
+      patch shop_log_path(shop1), params: { shop: { log_category: "dessert", log_note: "updated" } }
+
+      expect(response).to redirect_to(shop_logs_path)
+      expect(shop1.reload.log_category).to eq("dessert")
+    end
+
+    it "不正な値だと422を返すこと" do
+      sign_in user
+
+      patch shop_log_path(shop1), params: { shop: { log_note: "a" * 1001 } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "他人のshop logは更新できないこと" do
+      sign_in other_user
+
+      patch shop_log_path(shop1), params: { shop: { log_category: "dessert" } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/shops_spec.rb
+++ b/spec/requests/shops_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+
+RSpec.describe "Shops", type: :request do
+  let(:owner) { create(:user) }
+  let(:participant) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:event) { create(:event, user: owner) }
+
+  before do
+    create(:event_participant, event: event, user: owner)
+    create(:event_participant, event: event, user: participant)
+  end
+
+  describe "GET /events/:event_id/shops/new" do
+    it "未ログイン時はログイン画面にリダイレクトされること" do
+      get new_event_shop_path(event)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "参加者は表示できること" do
+      sign_in participant
+
+      get new_event_shop_path(event)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "非参加者はイベント詳細へ戻されること" do
+      sign_in other_user
+
+      get new_event_shop_path(event)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
+  describe "POST /events/:event_id/shops/fetch_name" do
+    let(:success_result) { ShopNameFetcher::Result.new(name: "shop name", error: nil) }
+    let(:failure_result) { ShopNameFetcher::Result.new(name: nil, error: "failed" ) }
+
+    it "参加者は成功時に200で店名JSONを受け取れること" do
+      sign_in participant
+      allow(ShopNameFetcher).to receive(:call).and_return(success_result)
+
+      post fetch_name_event_shops_path(event), params: { url: "https://example.com" }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq({ "name" => "shop name", "error" => nil })
+    end
+
+    it "失敗時は422でerrorを返すこと" do
+      sign_in participant
+      allow(ShopNameFetcher).to receive(:call).and_return(failure_result)
+
+      post fetch_name_event_shops_path(event), params: { url: "https://example.com" }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)).to eq({ "name" => nil, "error" => "failed" })
+    end
+
+    it "非参加者はイベント詳細へ戻されること" do
+      sign_in other_user
+
+      post fetch_name_event_shops_path(event), params: { url: "https://example.com" }
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
+  describe "POST /events/:event_id/shops" do
+    let(:valid_params) do
+      {
+        shop: {
+          name: "coffee shop",
+          url: "https://example.com",
+          memo: "memo"
+        }
+      }
+    end
+
+    before do
+      allow_any_instance_of(Shop).to receive(:fetch_place_id).and_return("place-123")
+      allow(ShopOgpImageFetcher).to receive(:call).and_return(
+        ShopOgpImageFetcher::Result.new(image_url: "https://example.com/image.png", error: nil)
+      )
+    end
+
+    it "参加者は作成できること" do
+      sign_in participant
+
+      expect {
+        post event_shops_path(event), params: valid_params
+      }.to change(Shop, :count).by(1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "不正な値だと作成されず422を返すこと" do
+      sign_in participant
+
+      expect {
+        post event_shops_path(event), params: { shop: valid_params[:shop].merge(name: "") }
+      }.not_to change(Shop, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "非参加者は作成できないこと" do
+      sign_in other_user
+
+      expect {
+        post event_shops_path(event), params: valid_params
+      }.not_to change(Shop, :count)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+
+  describe "PATCH /events/:event_id/shops/:id" do
+    let(:shop) { create(:shop, event: event, user: participant, name: "before", url: "https://before.example.com") }
+
+    before do
+      allow_any_instance_of(Shop).to receive(:fetch_place_id).and_return("place-123")
+      allow(ShopOgpImageFetcher).to receive(:call).and_return(
+        ShopOgpImageFetcher::Result.new(image_url: "https://example.com/image.png", error: nil)
+      )
+    end
+
+    it "所有者は更新できること" do
+      sign_in participant
+
+      patch event_shop_path(event, shop), params: { shop: { name: "after", url: "https://after.example.com", memo: "memo" } }
+
+      expect(response).to redirect_to(event_path(event))
+      expect(shop.reload.name).to eq("after")
+    end
+
+    it "他人は更新できないこと" do
+      sign_in owner
+
+      patch event_shop_path(event, shop), params: { shop: { name: "after" } }
+
+      expect(response).to redirect_to(event_path(event))
+      expect(shop.reload.name).to eq("before")
+    end
+
+    it "不正な値だと更新されず422を返すこと" do
+      sign_in participant
+
+      patch event_shop_path(event, shop), params: { shop: { name: "" } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(shop.reload.name).to eq("before")
+    end
+  end
+
+  describe "DELETE /events/:event_id/shops/:id" do
+    let!(:shop) { create(:shop, event: event, user: participant) }
+
+    it "所有者は削除できること" do
+      sign_in participant
+
+      expect {
+        delete event_shop_path(event, shop)
+      }.to change(Shop, :count).by(-1)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "他人は削除できないこと" do
+      sign_in owner
+
+      expect {
+        delete event_shop_path(event, shop)
+      }.not_to change(Shop, :count)
+
+      expect(response).to redirect_to(event_path(event))
+    end
+  end
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "StaticPages", type: :request do
+  it "トップページを表示できること" do
+    get root_path
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "利用規約ページを表示できること" do
+    get terms_path
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "プライバシーポリシーページを表示できること" do
+    get privacy_path
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Users::OmniauthCallbacks", type: :request do
+  around do |example|
+    original_test_mode = OmniAuth.config.test_mode
+    original_mock_auth = OmniAuth.config.mock_auth[:line]
+
+    OmniAuth.config.test_mode = true
+    example.run
+    OmniAuth.config.test_mode = original_test_mode
+    OmniAuth.config.mock_auth[:line] = original_mock_auth
+  end
+
+  describe "GET|POST /users/auth/line/callback" do
+    let(:auth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: "line",
+        uid: "line-uid-123",
+        info: OmniAuth::AuthHash::InfoHash.new(name: "line user")
+      )
+    end
+
+    it "初回ログイン時はuserを作成してdashboardへ遷移すること" do
+      OmniAuth.config.mock_auth[:line] = auth_hash
+
+      expect {
+        get user_line_omniauth_callback_path
+      }.to change(User, :count).by(1)
+
+      expect(response).to redirect_to(dashboard_path)
+      expect(User.last.provider).to eq("line")
+    end
+
+    it "既存userがいれば新規作成しないこと" do
+      create(:user, provider: "line", uid: "line-uid-123", email: "line@example.com", name: "line user")
+      OmniAuth.config.mock_auth[:line] = auth_hash
+
+      expect {
+        get user_line_omniauth_callback_path
+      }.not_to change(User, :count)
+
+      expect(response).to redirect_to(dashboard_path)
+    end
+
+    it "nameが空ならデフォルト名を使うこと" do
+      auth_without_name = OmniAuth::AuthHash.new(
+        provider: "line",
+        uid: "line-uid-456",
+        info: OmniAuth::AuthHash::InfoHash.new(name: nil)
+      )
+      OmniAuth.config.mock_auth[:line] = auth_without_name
+
+      get user_line_omniauth_callback_path
+
+      expect(User.last.name).to eq(I18n.t("defaults.line_user_name"))
+    end
+    
+    it "認証失敗時はログイン画面へリダイレクトされること" do
+      OmniAuth.config.mock_auth[:line] = :invalid
+
+      get user_line_omniauth_callback_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Users::Passwords", type: :request do
+  describe "GET /users/password/new" do
+    it "未ログイン時は表示できること" do
+      get new_user_password_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ログイン済みならdashboardへリダイレクトされること" do
+      user = create(:user)
+      sign_in user
+
+      get new_user_password_path
+
+      expect(response).to redirect_to(dashboard_path)
+    end
+  end
+
+  describe "GET /users/password/edit" do
+    it "ログイン済みならdashboardへリダイレクトされること" do
+      user = create(:user)
+      sign_in user
+
+      get edit_user_password_path, params: { reset_password_token: "token" }
+
+      expect(response).to redirect_to(dashboard_path)
+    end
+  end
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Users::Registrations", type: :request do
+  describe "GET /users/sign_up" do
+    it "未ログイン時は表示できること" do
+      get new_user_registration_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ログイン済みならdashboardへリダイレクトされること" do
+      user = create(:user)
+      sign_in user
+
+      get new_user_registration_path
+
+      expect(response).to redirect_to(dashboard_path)
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Users::Sessions", type: :request do
+  describe "GET /users/sign_in" do
+    it "未ログイン時は表示できること" do
+      get new_user_session_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ログイン済みならdashboardへリダイレクトされること" do
+      user = create(:user)
+      sign_in user
+
+      get new_user_session_path
+
+      expect(response).to redirect_to(dashboard_path)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
主要機能と周辺機能の request spec を追加し、HTTP リクエストの流れを RSpec で守れるようにした。
あわせて request spec 実行に必要な設定を追加し、ShopLogsController の認証も補強した。

## 実装内容
- `EventsController` の request spec を追加
- `ShopsController` の request spec を追加
- `LikesController` の request spec を追加
- `EventParticipantsController` の request spec を追加
- `EventPreferencesController` の request spec を追加
- `ShopLogsController` の request spec を追加
- `DashboardController` の request spec を追加
- `StaticPagesController` の request spec を追加
- `Users::SessionsController` の request spec を追加
- `Users::RegistrationsController` の request spec を追加
- `Users::PasswordsController` の request spec を追加
- `Users::OmniauthCallbacksController` の request spec を追加
- request spec 用に `Devise::Test::IntegrationHelpers` を追加
- `ShopLogsController` に `authenticate_user!` を追加

## 動作確認
- [x] `bundle exec rspec` が通る
- [x] `125 examples, 0 failures`
- [x] request spec で認証 / 認可 / CRUD / JSON レスポンスを確認できる
- [x] coverage が `84.75% (328 / 387)` であることを確認できる

## 補足
- model spec と request spec を合わせた full run の coverage 結果は `84.75% (328 / 387)`
- `ShopLogsController` は request spec を通す中で認証不足が見つかったため補強した
- system spec は今回の対象外

Close #65 
