### PR TITLE
feat: システムスペックを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,42 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build frontend assets
+        run: |
+          yarn build
+          yarn build:css
+
+      - name: Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+
       - name: Prepare test database
         run: bin/rails db:prepare
+
+      - name: Run RSpec
+        env:
+          CI: true
+        run: bundle exec rspec
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+          if-no-files-found: ignore
+
+      - name: Add coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/.last_run.json ]; then
+            ruby -rjson -e 'data = JSON.parse(File.read("coverage/.last_run.json")); puts "## Coverage"; puts; puts "- Line Coverage: #{data.dig("result", "line")}%"' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 !/tmp/storage/.keep
 
 /public/assets
+/coverage
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN apt-get update -qq \
 && curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg \
 && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim chromium chromium-driver
 
 RUN mkdir /myapp
 WORKDIR /myapp

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+require "capybara/rspec"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,7 +24,30 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+
+Capybara.register_driver :headless_chromium do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.binary = "/usr/bin/chromium" if File.exist?("/usr/bin/chromium")
+  options.add_argument("--headless=new")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--window-size=1400,1400")
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+class ActiveRecord::Base
+  mattr_accessor :shared_connection, default: nil
+
+  class << self
+    alias_method :original_connection, :connection
+
+    def connection
+      shared_connection || original_connection
+    end
+  end
+end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -40,6 +64,8 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include SystemHelpers, type: :system
+  config.include Warden::Test::Helpers, type: :system
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -65,6 +91,23 @@ RSpec.configure do |config|
   #
   # To enable this behaviour uncomment the line below.
   config.infer_spec_type_from_file_location!
+
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+    driven_by :headless_chromium
+  end
+
+  config.after(:each, type: :system, js: true) do
+    ActiveRecord::Base.shared_connection = nil
+  end
+
+  config.after(:each, type: :system) do
+    Warden.test_reset!
+  end
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SystemHelpers
+  def sign_in_as(user)
+    visit new_user_session_path
+    fill_in "user_email", with: user.email
+    fill_in "user_password", with: "password123"
+    click_button I18n.t("views.devise.sessions.new.submit")
+  end
+
+  def sign_in_for_js(user)
+    login_as(user, scope: :user)
+  end
+
+  def shop_card_for(name)
+    find(:xpath, "//article[.//h3[normalize-space()='#{name}']]", match: :first)
+  end
+end

--- a/spec/system/event_participation_spec.rb
+++ b/spec/system/event_participation_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "イベント参加導線", type: :system do
+  it "共有URLからログインしてイベントに参加できること" do
+    user = create(:user)
+    event = create(:event, title: "共有イベント")
+
+    visit join_event_path(event.unique_url)
+
+    expect(page).to have_content("共有イベント")
+    click_link I18n.t("views.events.join.login_button")
+
+    fill_in "user_email", with: user.email
+    fill_in "user_password", with: "password123"
+    click_button I18n.t("views.devise.sessions.new.submit")
+
+    expect(page).to have_current_path(join_event_path(event.unique_url), ignore_query: true)
+
+    expect do
+      click_button I18n.t("views.events.join.join_button")
+    end.to change(EventParticipant, :count).by(1)
+
+    expect(page).to have_current_path(event_path(event), ignore_query: true)
+    expect(page).to have_content(I18n.t("views.events.show.joined"))
+    expect(page).to have_link(I18n.t("views.events.shops.new_shop"))
+  end
+end

--- a/spec/system/event_preferences_spec.rb
+++ b/spec/system/event_preferences_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "希望条件投稿導線", type: :system, js: true do
+  it "参加者が希望条件を入力して保存できること" do
+    owner = create(:user)
+    participant = create(:user)
+    event = create(:event, user: owner)
+    create(:event_participant, event: event, user: participant)
+
+    sign_in_for_js(participant)
+    visit event_path(event)
+
+    find("label", text: I18n.t("views.events.preferences.open_form")).click
+
+    fill_in "event_preference_dislike_foods", with: "パクチー"
+    select I18n.t("views.events.preferences.option_3"), from: "event_preference_budget"
+    fill_in "event_preference_content", with: "落ち着いたお店が良い"
+
+    within(".modal-box", text: I18n.t("views.events.preferences.open_form")) do
+      click_button I18n.t("common.save")
+    end
+
+    expect(page).to have_content("パクチー")
+    expect(page).to have_content(I18n.t("views.events.preferences.option_3"))
+    expect(page).to have_content("落ち着いたお店が良い")
+  end
+end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "イベント導線", type: :system do
+  it "ログインしてイベントを作成し、詳細画面へ遷移できること" do
+    user = create(:user)
+
+    sign_in_as(user)
+    within("article", text: I18n.t("views.dashboard.cards.events_new_title")) do
+      click_link I18n.t("views.dashboard.cards.events_new_link")
+    end
+
+    fill_in "event_title", with: "金曜ランチ会"
+    fill_in "event_event_date", with: Date.current.strftime("%Y-%m-%d")
+    fill_in "event_event_time", with: "18:30"
+    fill_in "event_place", with: "新宿"
+    fill_in "event_note", with: "駅近で集まりたい"
+
+    expect do
+      click_button I18n.t("common.create")
+    end.to change(Event, :count).by(1)
+      .and change(EventParticipant, :count).by(1)
+
+    event = Event.order(:created_at).last
+
+    expect(page).to have_current_path(event_path(event), ignore_query: true)
+    expect(page).to have_content("金曜ランチ会")
+    expect(page).to have_content("新宿")
+    expect(page).to have_content(user.name)
+  end
+
+  it "イベント作成者には編集・削除ボタンが表示されること" do
+    owner = create(:user)
+    event = create(:event, user: owner, title: "作成者イベント")
+    create(:event_participant, event: event, user: owner)
+
+    sign_in_as(owner)
+    visit event_path(event)
+
+    expect(page).to have_link(I18n.t("common.edit"))
+    expect(page).to have_link(I18n.t("common.delete"))
+  end
+
+  it "他のユーザーには編集・削除ボタンが表示されないこと" do
+    owner = create(:user)
+    other_user = create(:user)
+    event = create(:event, user: owner, title: "他人イベント")
+    create(:event_participant, event: event, user: other_user)
+
+    sign_in_as(other_user)
+    visit event_path(event)
+
+    expect(page).not_to have_link(I18n.t("common.edit"))
+    expect(page).not_to have_link(I18n.t("common.delete"))
+  end
+end

--- a/spec/system/likes_spec.rb
+++ b/spec/system/likes_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "いいね導線", type: :system, js: true do
+  it "参加者がイベント詳細からいいねできること" do
+    owner = create(:user)
+    participant = create(:user)
+    event = create(:event, user: owner)
+    create(:event_participant, event: event, user: participant)
+    shop = create(:shop, event: event, user: owner, name: "いいねカフェ")
+
+    sign_in_for_js(participant)
+    visit event_path(event)
+
+    shop_card = shop_card_for(shop.name)
+
+    within(shop_card) do
+      expect(page).to have_link(I18n.t("views.events.shops.like"))
+      expect(page).to have_content("0")
+      click_link I18n.t("views.events.shops.like")
+      expect(page).to have_link(I18n.t("views.events.shops.unlike"))
+      expect(page).to have_content("1")
+    end
+  end
+end

--- a/spec/system/shops_spec.rb
+++ b/spec/system/shops_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "お店候補登録導線", type: :system do
+  before do
+    allow_any_instance_of(Shop).to receive(:fetch_place_id).and_return("place-123")
+    allow(ShopOgpImageFetcher).to receive(:call).and_return(
+      ShopOgpImageFetcher::Result.new(image_url: "https://example.com/shop.png", error: nil)
+    )
+  end
+
+  it "イベント参加者がお店候補を登録して詳細画面に表示できること" do
+    owner = create(:user)
+    participant = create(:user)
+    event = create(:event, user: owner, title: "候補登録イベント")
+    create(:event_participant, event: event, user: participant)
+
+    sign_in_as(participant)
+    visit event_path(event)
+    click_link I18n.t("views.events.shops.new_shop")
+
+    fill_in "shop_url", with: "https://example.com/cafe"
+    fill_in "shop_name", with: "テストカフェ"
+    fill_in "shop_memo", with: "プリンが人気"
+
+    expect do
+      click_button I18n.t("common.create")
+    end.to change(Shop, :count).by(1)
+
+    expect(page).to have_current_path(event_path(event), ignore_query: true)
+    expect(page).to have_content("テストカフェ")
+    expect(page).to have_content("プリンが人気")
+  end
+
+  it "お店候補の登録者には編集・削除ボタンが表示されること" do
+    owner = create(:user)
+    participant = create(:user)
+    event = create(:event, user: owner)
+    create(:event_participant, event: event, user: participant)
+    shop = create(:shop, event: event, user: participant, name: "編集確認カフェ")
+
+    sign_in_as(participant)
+    visit event_path(event)
+
+    shop_card = shop_card_for(shop.name)
+
+    within(shop_card) do
+      expect(page).to have_link(I18n.t("common.edit"))
+      expect(page).to have_link(I18n.t("common.delete"))
+    end
+  end
+
+  it "他の参加者には編集・削除ボタンが表示されないこと" do
+    owner = create(:user)
+    shop_owner = create(:user)
+    other_user = create(:user)
+    event = create(:event, user: owner)
+    create(:event_participant, event: event, user: shop_owner)
+    create(:event_participant, event: event, user: other_user)
+    shop = create(:shop, event: event, user: shop_owner, name: "権限確認カフェ")
+
+    sign_in_as(other_user)
+    visit event_path(event)
+
+    shop_card = shop_card_for(shop.name)
+
+    within(shop_card) do
+      expect(page).not_to have_link(I18n.t("common.edit"))
+      expect(page).not_to have_link(I18n.t("common.delete"))
+    end
+  end
+end


### PR DESCRIPTION
## 概要
主要な画面導線をユーザー操作ベースで担保するため、system spec を追加した。
あわせて system spec 実行環境を整備し、coverage と CI の確認フローも追加した。

## 実装内容
- `events_spec` を追加
  - ログイン後にイベントを作成できる導線を確認
  - 作成者 / 他人で編集・削除ボタン表示が変わることを確認
- `event_participation_spec` を追加
  - 共有URL経由でイベントに参加できる導線を確認
- `shops_spec` を追加
  - 参加者がお店候補を登録できる導線を確認
  - 登録者 / 他人で編集・削除ボタン表示が変わることを確認
- `likes_spec` を追加
  - 参加者がイベント詳細からいいねできる導線を確認
- `event_preferences_spec` を追加
  - 参加者が希望条件を入力して保存できる導線を確認
- `spec/support/system_helpers.rb` を追加
- `spec/rails_helper.rb` に system spec 用設定を追加
- `Dockerfile.dev` に Chromium / chromedriver を追加
- `.gitignore` に `coverage/` を追加
- `.github/workflows/ci.yml` に
  - frontend build
  - Chrome セットアップ
  - `bundle exec rspec`
  - coverage artifact / summary
  を追加

## 動作確認
- [x] `bundle exec rspec spec/system` が通る
- [x] `bundle exec rspec` が通る
- [x] `134 examples, 0 failures`
- [x] system spec で主要導線が確認できる
- [x] GitHub Actions 上で RSpec と coverage を確認できる

## 補足
- full run の coverage 結果は `85.01% (329 / 387)`
- `coverage/` は生成物のため Git 管理対象から外した
- OmniAuth failure のログは failure 導線をテストしている影響で、spec 自体は成功している
- request spec は前 PR で対応済み

Closes #125
