### PR TITLE
chore: GitHub Actions の warning 対応を行う

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -39,7 +39,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: yarn
@@ -53,7 +53,7 @@ jobs:
           yarn build:css
 
       - name: Set up Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
 
       - name: Prepare test database
         run: bin/rails db:prepare
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage


### PR DESCRIPTION
## 概要
GitHub Actions 実行時に表示されていた Node.js 20 廃止予告 warning に対応するため、workflow 内で利用している action のバージョンを更新した。

## 実装内容
- `actions/checkout` を `v6` に更新
- `actions/setup-node` を `v6` に更新
- `browser-actions/setup-chrome` を `v2` に更新
- `actions/upload-artifact` を `v6` に更新

## 動作確認
- [x] GitHub Actions が通る
- [x] warning が解消または減っている
- [x] RSpec / coverage の既存フローが壊れていない

## 補足
- アプリ本体のコード変更はなし
- CI workflow のメンテナンス対応のみ