### PR TITLE
fix: 本番のパスワード再設定メール設定を補強する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,10 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "gohankaigi.com"),
+    protocol: ENV.fetch("APP_PROTOCOL", "https")
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV.fetch("MAILER_SENDER", "no-reply@gohankaigi.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 概要
本番環境でパスワード再設定時に 500 エラーが発生していたため、メールURL生成と送信元設定を補強した。

## 実装内容
- `production.rb` に `action_mailer.default_url_options` を追加
- `devise.rb` の `mailer_sender` を環境変数ベースに変更
- 本番メール本文URL生成に必要な host / protocol を明示

## 動作確認
- [ ] 本番環境でパスワード再設定メール送信が成功する
- [ ] 再設定メール内のリンクからパスワード再設定画面へ遷移できる
- [ ] `APP_HOST` / `APP_PROTOCOL` / `MAILER_SENDER` の設定が本番環境に入っている

## 補足
- 既定値として `APP_HOST=gohankaigi.com`、`APP_PROTOCOL=https`、`MAILER_SENDER=no-reply@gohankaigi.com` を想定
- SMTP / delivery method 側の設定不足がある場合は、追加で本番環境の設定確認が必要