### PR TITLE
fix: Gmail SMTPで本番メール送信できるようにする

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,19 @@ Rails.application.configure do
     host: ENV.fetch("APP_HOST", "gohankaigi.com"),
     protocol: ENV.fetch("APP_PROTOCOL", "https")
   }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: ENV.fetch("APP_HOST", "gohankaigi.com"),
+    user_name: ENV.fetch("MAILER_SENDER"),
+    password: ENV.fetch("MAILER_PASSWORD"),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 概要
本番環境でパスワード再設定メール送信時に 500 エラーが発生していたため、Action Mailer と Devise のメール設定を補強した。

## 実装内容
- `config/initializers/devise.rb`
  - `mailer_sender` を環境変数ベースに変更
- `config/environments/production.rb`
  - `action_mailer.default_url_options` を追加
  - Gmail SMTP を使う `delivery_method` / `smtp_settings` を追加
  - `perform_deliveries` / `raise_delivery_errors` を有効化

## 動作確認
- [x] Render の環境変数に以下を設定
  - `MAILER_SENDER`
  - `MAILER_PASSWORD`
  - `APP_HOST`
  - `APP_PROTOCOL`
- [x] Render で再デプロイ
- [ ] 本番環境で `/users/password/new` から再設定メール送信を確認
- [ ] 再設定メール内リンクからパスワード更新画面へ遷移できることを確認

## 補足
- 本番ログでは `Connection refused - connect(2) for "localhost" port 25` が出ており、SMTP 未設定が原因だった
- Gmail の通常パスワードではなく、Google アカウントのアプリパスワードを利用する
- 本番の環境変数設定も合わせて必要