### PR TITLE
fix: SendGridで本番メール送信できるようにする

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,19 +75,19 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("APP_HOST", "gohankaigi.com"),
-    protocol: ENV.fetch("APP_PROTOCOL", "https")
+    host: ENV.fetch("MAILER_HOST", "gohankaigi.com"),
+    protocol: "https"
   }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
+    address: "smtp.sendgrid.net",
     port: 587,
-    domain: ENV.fetch("APP_HOST", "gohankaigi.com"),
-    user_name: ENV.fetch("MAILER_SENDER"),
-    password: ENV.fetch("MAILER_PASSWORD"),
+    domain: ENV.fetch("MAILER_HOST", "gohankaigi.com"),
+    user_name: "apikey",
+    password: ENV.fetch("SENDGRID_API_KEY"),
     authentication: :plain,
     enable_starttls_auto: true
   }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch("MAILER_SENDER", "no-reply@gohankaigi.com")
+  config.mailer_sender = ENV.fetch("MAILER_FROM", "no-reply@gohankaigi.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 概要
本番環境でパスワード再設定メール送信時に発生していた不具合に対して、Action Mailer と Devise のメール設定を SendGrid ベースへ切り替えた。

## 実装内容
- `config/environments/production.rb`
  - `action_mailer.default_url_options` を `MAILER_HOST` ベースに整理
  - SMTP 設定を Gmail から SendGrid に切り替え
  - `perform_deliveries` / `raise_delivery_errors` を有効化
- `config/initializers/devise.rb`
  - `mailer_sender` を `MAILER_FROM` ベースに変更

## 動作確認
- [x] Render の環境変数に以下を設定
  - `SENDGRID_API_KEY`
  - `MAILER_FROM`
  - `MAILER_HOST`
- [x] Render で再デプロイ
- [ ] 本番環境で `/users/password/new` から再設定メール送信を確認
- [ ] 再設定メール内リンクからパスワード更新画面へ遷移できることを確認

## 補足
- Gmail SMTP では本番で `Net::OpenTimeout` が発生したため、アプリ向け送信サービスの SendGrid に切り替えた
- Google 用の環境変数は、本番確認後に Render から削除予定