### PR TITLE
fix: 本リリース向けにパスワード再設定導線を閉じる

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,5 +1,6 @@
 class Users::PasswordsController < Devise::PasswordsController
   before_action :redirect_if_authenticated, only: %i[new edit]
+  before_action :redirect_unreleased_password_reset, only: %i[new create edit update]
 
   private
 
@@ -7,5 +8,10 @@ class Users::PasswordsController < Devise::PasswordsController
     return unless user_signed_in?
 
     redirect_to dashboard_path, alert: t("flash.devise.already_authenticated.alert")
+  end
+
+  def redirect_unreleased_password_reset
+    redirect_to new_user_session_path,
+      alert: t("flash.devise.password_reset_unavailable.alert")
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,7 +34,6 @@
             </div>
 
             <div class="flex items-center justify-end pt-1">
-              <%= link_to t("views.devise.sessions.new.forgot_password"), new_user_password_path, class: "link link-hover text-sm text-base-content/60" %>
             </div>
 
             <div class="pt-1">

--- a/config/locales/ja.flash.yml
+++ b/config/locales/ja.flash.yml
@@ -56,5 +56,7 @@ ja:
   devise:
     already_authenticated:
       alert: "すでにログインしています"
+    password_reset_unavailable:
+      alert: "パスワード再設定機能は本リリース後に公開予定です"
     account_settings_unavailable:
       alert: "アカウント設定機能は本リリース後に公開予定です"


### PR DESCRIPTION
## 概要
本番環境でパスワード再設定メール送信を実装しようとしたが、Render Free 環境で SMTP 接続が安定せず 500 エラーになっていたため、本リリースではパスワード再設定導線を一時的に閉じる対応を行った。

## 実装内容
- ログイン画面の「パスワードを忘れた方」リンクを削除
- `Users::PasswordsController` で `new/create/edit/update` へのアクセスをログイン画面へリダイレクト
- 本リリース後公開予定の alert 文言を追加

## 動作確認
- [x] ログイン画面にパスワード再設定リンクが表示されないことを確認
- [x] `/users/password/new` に直接アクセスするとログイン画面へ戻ることを確認
- [ ] `パスワード再設定機能は本リリース後に公開予定です` の alert が表示されることを確認

## 補足
- 本番では Gmail SMTP と SendGrid SMTP の両方を試した
- ただし Render Free 環境で `Net::OpenTimeout` が継続し、本リリース時点で安定運用が難しいと判断した
- 壊れた導線を見せないことを優先し、本リリースでは一旦閉じる
- メール送信基盤は本リリース後に再検討する