### PR TITLE
fix: deviseのflash文言キーを修正する

### DIFF
--- a/config/locales/ja.flash.yml
+++ b/config/locales/ja.flash.yml
@@ -53,10 +53,10 @@ ja:
         notice: "LINEでログインしました"
       line_login_failed:
         alert: "LINEログインに失敗しました"
-  devise:
-    already_authenticated:
-      alert: "すでにログインしています"
-    password_reset_unavailable:
-      alert: "パスワード再設定機能は本リリース後に公開予定です"
-    account_settings_unavailable:
-      alert: "アカウント設定機能は本リリース後に公開予定です"
+    devise:
+      already_authenticated:
+        alert: "すでにログインしています"
+      password_reset_unavailable:
+        alert: "パスワード再設定機能は本リリース後に公開予定です"
+      account_settings_unavailable:
+        alert: "アカウント設定機能は本リリース後に公開予定です"


### PR DESCRIPTION
## 概要
devise 関連の flash 文言キー階層を修正した。

## 実装内容
- `ja.flash.yml` の devise 関連キーを `flash` 配下へ移動
- controller の参照先と locale の階層を一致させた

## 動作確認
- [x] パスワード再設定導線の alert が日本語で表示されることを確認

## 補足
- locale のキー階層ずれにより、想定した日本語文言が解決されていなかったため修正した