### PR TITLE
test: パスワード再設定導線の一時クローズにRSpecを追従する

### DIFF
--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Users::Passwords", type: :request do
   describe "GET /users/password/new" do
-    it "未ログイン時は表示できること" do
+    it "未ログイン時はログイン画面へリダイレクトされること" do
       get new_user_password_path
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to(new_user_session_path)
     end
 
     it "ログイン済みならdashboardへリダイレクトされること" do
@@ -18,7 +18,21 @@ RSpec.describe "Users::Passwords", type: :request do
     end
   end
 
+  describe "POST /users/password" do
+    it "未ログイン時はログイン画面へリダイレクトされること" do
+      post user_password_path, params: { user: { email: "test@example.com" } }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
   describe "GET /users/password/edit" do
+    it "未ログイン時はログイン画面へリダイレクトされること" do
+      get edit_user_password_path, params: { reset_password_token: "token" }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
     it "ログイン済みならdashboardへリダイレクトされること" do
       user = create(:user)
       sign_in user


### PR DESCRIPTION
## 概要
本リリース向けに一時的に閉じたパスワード再設定導線の仕様に合わせて、request spec を追従した。

## 実装内容
- `GET /users/password/new` の期待値を `200 OK` からログイン画面へのリダイレクトに変更
- `POST /users/password` の未ログイン時リダイレクト確認を追加
- `GET /users/password/edit` の未ログイン時リダイレクト確認を追加

## 動作確認
- [ ] `spec/requests/users/passwords_spec.rb` が通ることを確認
- [ ] パスワード再設定導線を閉じた現仕様と一致していることを確認

## 補足
- 本リリースではパスワード再設定導線を一時的に閉じているため、既存 spec の期待値を現仕様に合わせて調整した
- 将来パスワード再設定機能を再開する際は、spec も再度見直す