### PR TITLE
docs: READMEのOGP画像表示を調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ごはん会議
 
-<img src="app/assets/images/ogp.png" width="700" alt="ごはん会議 OGP">
+<p align="center">
+  <img src="app/assets/images/ogp.png" width="700" alt="ごはん会議 OGP">
+</p>
 
 ## サービス概要
 ごはん会議は、複数人で「どこのお店に行くか」を決める過程と結果を記録として残せる、提案・投票型のお店選び共有アプリです。  


### PR DESCRIPTION
## 概要
README の OGP 画像が左寄せで小さく見えていたため、中央寄せに調整した。

## 実装内容
- `README.md`
  - OGP 画像を中央寄せに変更

## 動作確認
- [x] README 上で OGP 画像が中央に表示されることを確認

## 補足
- アプリ本体の変更はなし
- README の見た目調整のみ