### PR TITLE
fix: お店ログ検索のLIKE検索を安全化する

### DIFF
--- a/app/controllers/shop_logs_controller.rb
+++ b/app/controllers/shop_logs_controller.rb
@@ -9,7 +9,7 @@ class ShopLogsController < ApplicationController
     @shops = current_user.shops.includes(:event)
 
     # 検索
-    @shops = @shops.where("name LIKE ?", "%#{params[:q]}%") if params[:q].present?
+    @shops = @shops.where("name LIKE ?", like_query(params[:q])) if params[:q].present?
 
     # カテゴリ絞り込み
     @shops = @shops.where(log_category: params[:category]) if params[:category].present?
@@ -35,7 +35,7 @@ class ShopLogsController < ApplicationController
     shops = current_user.shops
 
     shops = if params[:q].present?
-              shops.where("name LIKE ?", "%#{params[:q]}%").limit(AUTOCOMPLETE_LIMIT)
+              shops.where("name LIKE ?", like_query(params[:q])).limit(AUTOCOMPLETE_LIMIT)
     else
               []
     end
@@ -73,5 +73,9 @@ class ShopLogsController < ApplicationController
 
   def current_sort
     params[:sort].presence
+  end
+
+  def like_query(query)
+    "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
   end
 end

--- a/spec/requests/shop_logs_spec.rb
+++ b/spec/requests/shop_logs_spec.rb
@@ -41,6 +41,30 @@ RSpec.describe "ShopLogs", type: :request do
       expect(response.body).to include("coffee")
       expect(response.body).not_to include("ramen")
     end
+
+    it "% を含む文字列でもそのまま検索できること" do
+      create(:shop, event: event, user: user, name: "100% cafe")
+      create(:shop, event: event, user: user, name: "1000 cafe")
+
+      sign_in user
+
+      get shop_logs_path, params: { q: "%" }
+
+      expect(response.body).to include("100% cafe")
+      expect(response.body).not_to include("1000 cafe")
+    end
+
+    it "_ を含む文字列でもそのまま検索できること" do
+      create(:shop, event: event, user: user, name: "ramen_house")
+      create(:shop, event: event, user: user, name: "ramen house")
+
+      sign_in user
+
+      get shop_logs_path, params: { q: "_" }
+
+      expect(response.body).to include("ramen_house")
+      expect(response.body).not_to include("ramen house")
+    end
   end
 
   describe "GET /shop_logs/autocomplete" do
@@ -73,6 +97,36 @@ RSpec.describe "ShopLogs", type: :request do
       expect(response).to have_http_status(:ok)
       expect(result.size).to eq(5)
       expect(result).to all(include("coffee"))
+    end
+
+    it "% を含む文字列でもそのまま候補検索できること" do
+      create(:shop, event: event, user: user, name: "100% cafe")
+      create(:shop, event: event, user: user, name: "1000 cafe")
+
+      sign_in user
+
+      get shop_logs_autocomplete_path, params: { q: "%" }
+
+      result = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(result).to include("100% cafe")
+      expect(result).not_to include("1000 cafe")
+    end
+
+    it "_ を含む文字列でもそのまま候補検索できること" do
+      create(:shop, event: event, user: user, name: "ramen_house")
+      create(:shop, event: event, user: user, name: "ramen house")
+
+      sign_in user
+
+      get shop_logs_autocomplete_path, params: { q: "_" }
+
+      result = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(result).to include("ramen_house")
+      expect(result).not_to include("ramen house")
     end
   end
 


### PR DESCRIPTION
## 概要
お店ログ一覧とオートコンプリートで使っている LIKE 検索を安全化した。

## 実装内容
- `ShopLogsController#index` の検索で `sanitize_sql_like` を使用するように修正
- `ShopLogsController#autocomplete` の検索も同様に修正
- `%` / `_` を含む検索文字列の request spec を追加

## 動作確認
- [x] `docker compose run --rm web bash -lc "bundle exec rails db:prepare && bundle exec rspec spec/requests/shop_logs_spec.rb"`
- [x] `docker compose run --rm web bash -lc "bundle exec rubocop app/controllers/shop_logs_controller.rb spec/requests/shop_logs_spec.rb"`
- [x] 通常検索の挙動が変わっていないこと
- [x] `%` / `_` を含む検索文字列でも意図しないワイルドカード検索になりにくいこと

## 補足
- 講師フィードバックで指摘のあった `LIKE` 検索の安全化に対応
- 同じ問題があった `autocomplete` もあわせて修正

Closes #160 