### PR TITLE
refactor: place_id取得処理をサービス層へ切り出す

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -25,7 +25,7 @@ class ShopsController < ApplicationController
     @shop = @event.shops.new(shop_params)
     @shop.user = current_user
 
-    @shop.place_id = @shop.fetch_place_id(@event.place)
+    @shop.place_id = ShopPlaceIdFetcher.call(@shop.map_query(@event.place))
     @shop.ogp_image_url = fetch_ogp_image_url(@shop.url)
 
     if @shop.save
@@ -41,7 +41,7 @@ class ShopsController < ApplicationController
 
     # 名前が変更された場合のみ place_id を再取得
     if @shop.will_save_change_to_name?
-      new_place_id = @shop.fetch_place_id(@event.place)
+      new_place_id = ShopPlaceIdFetcher.call(@shop.map_query(@event.place))
       @shop.place_id = new_place_id if new_place_id.present?
     end
 

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -28,21 +28,4 @@ class Shop < ApplicationRecord
   def map_link_url(event_place = nil)
     "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(map_query(event_place))}"
   end
-
-  # Places APIを使ってplace_idを取得する（店名 + イベント場所から検索）
-  def fetch_place_id(event_place = nil)
-    query = map_query(event_place)
-
-    response = Faraday.post(
-      "https://places.googleapis.com/v1/places:searchText"
-    ) do |req|
-      req.headers["Content-Type"] = "application/json"
-      req.headers["X-Goog-Api-Key"] = ENV.fetch("GOOGLE_MAPS_API_KEY", nil)
-      req.headers["X-Goog-FieldMask"] = "places.id"
-      req.body = { textQuery: query }.to_json
-    end
-
-    data = JSON.parse(response.body)
-    data["places"]&.first&.dig("id")
-  end
 end

--- a/app/services/shop_place_id_fetcher.rb
+++ b/app/services/shop_place_id_fetcher.rb
@@ -1,0 +1,25 @@
+class ShopPlaceIdFetcher
+  def self.call(query)
+    new(query).call
+  end
+
+  def initialize(query)
+    @query = query.to_s.strip
+  end
+
+  def call
+    return if @query.blank?
+
+    response = Faraday.post(
+      "https://places.googleapis.com/v1/places:searchText"
+    ) do |req|
+      req.headers["Content-Type"] = "application/json"
+      req.headers["X-Goog-Api-Key"] = ENV.fetch("GOOGLE_MAPS_API_KEY", nil)
+      req.headers["X-Goog-FieldMask"] = "places.id"
+      req.body = { textQuery: @query }.to_json
+    end
+
+    data = JSON.parse(response.body)
+    data["places"]&.first&.dig("id")
+  end
+end

--- a/spec/models/shop_spec.rb
+++ b/spec/models/shop_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Shop, type: :model do
       expect(shop).not_to be_valid
       expect(shop.errors[:user]).to be_present
     end
-  end
+end
 
   describe "関連" do
     it "liked_usersからいいねしたuserを参照できること" do
@@ -113,30 +113,6 @@ RSpec.describe Shop, type: :model do
       expect(shop.map_link_url("shinjuku")).to eq(
         "https://www.google.com/maps/search/?api=1&query=coffee+shinjuku"
       )
-    end
-  end
-
-  describe "#fetch_place_id" do
-    it "Places APIの先頭idを返すこと" do
-      shop = build(:shop, name: "coffee")
-      response = instance_double(Faraday::Response, body: { places: [ { id: "place-123" } ] }.to_json)
-
-      allow(Faraday).to receive(:post).and_return(response)
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
-
-      expect(shop.fetch_place_id("shinjuku")).to eq("place-123")
-    end
-
-    it "候補がない場合はnilを返すこと" do
-      shop = build(:shop, name: "coffee")
-      response = instance_double(Faraday::Response, body: {}.to_json)
-
-      allow(Faraday).to receive(:post).and_return(response)
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
-
-      expect(shop.fetch_place_id("shinjuku")).to be_nil
     end
   end
 end

--- a/spec/requests/shops_spec.rb
+++ b/spec/requests/shops_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Shops", type: :request do
     end
 
     before do
-      allow_any_instance_of(Shop).to receive(:fetch_place_id).and_return("place-123")
+      allow(ShopPlaceIdFetcher).to receive(:call).and_return("place-123")
       allow(ShopOgpImageFetcher).to receive(:call).and_return(
         ShopOgpImageFetcher::Result.new(image_url: "https://example.com/image.png", error: nil)
       )
@@ -137,7 +137,7 @@ RSpec.describe "Shops", type: :request do
     let(:shop) { create(:shop, event: event, user: participant, name: "before", url: "https://before.example.com") }
 
     before do
-      allow_any_instance_of(Shop).to receive(:fetch_place_id).and_return("place-123")
+      allow(ShopPlaceIdFetcher).to receive(:call).and_return("place-123")
       allow(ShopOgpImageFetcher).to receive(:call).and_return(
         ShopOgpImageFetcher::Result.new(image_url: "https://example.com/image.png", error: nil)
       )

--- a/spec/services/shop_place_id_fetcher_spec.rb
+++ b/spec/services/shop_place_id_fetcher_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ShopPlaceIdFetcher do
+  describe ".call" do
+    it "Places APIの先頭idを返すこと" do
+      response = instance_double(Faraday::Response, body: { places: [ { id: "place-123" } ] }.to_json)
+
+      allow(Faraday).to receive(:post).and_return(response)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
+
+      expect(described_class.call("coffee shinjuku")).to eq("place-123")
+    end
+
+    it "候補がない場合はnilを返すこと" do
+      response = instance_double(Faraday::Response, body: {}.to_json)
+
+      allow(Faraday).to receive(:post).and_return(response)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("GOOGLE_MAPS_API_KEY", nil).and_return("test-key")
+
+      expect(described_class.call("coffee shinjuku")).to be_nil
+    end
+
+    it "空文字の場合はnilを返すこと" do
+      expect(described_class.call("")).to be_nil
+    end
+  end
+end

--- a/spec/system/shops_spec.rb
+++ b/spec/system/shops_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "お店候補登録導線", type: :system do
   before do
-    allow_any_instance_of(Shop).to receive(:fetch_place_id).and_return("place-123")
+    allow(ShopPlaceIdFetcher).to receive(:call).and_return("place-123")
     allow(ShopOgpImageFetcher).to receive(:call).and_return(
       ShopOgpImageFetcher::Result.new(image_url: "https://example.com/shop.png", error: nil)
     )


### PR DESCRIPTION
## 概要
`Shop` モデルにあった place_id 取得処理をサービス層へ切り出した。

## 実装内容
- `Shop#fetch_place_id` をモデルから削除
- `ShopPlaceIdFetcher` を追加し、Google Places API 呼び出しを移動
- `ShopsController#create` / `update` の呼び出し先をサービスへ変更
- `fetch_place_id` に関する model spec を service spec へ整理
- request spec / system spec の stub 先を新サービスに合わせて更新

## 動作確認
- [x] `docker compose run --rm web bash -lc "bundle exec rails db:prepare && bundle exec rspec spec/services/shop_place_id_fetcher_spec.rb spec/models/shop_spec.rb spec/requests/shops_spec.rb spec/system/shops_spec.rb"`
- [x] `docker compose run --rm web bash -lc "bundle exec rubocop app/services/shop_place_id_fetcher.rb app/models/shop.rb app/controllers/shops_controller.rb spec/services/shop_place_id_fetcher_spec.rb spec/models/shop_spec.rb spec/requests/shops_spec.rb spec/system/shops_spec.rb"`
- [x] ブラウザでお店候補の新規作成 / 更新ができることを確認

## 補足
- 外部API連携の責務をモデルから分離し、既存のサービス層設計と一貫する形へ整理した
- ユーザー向けの挙動は変えず、内部設計の整理を目的とした変更

Closes #161 