### PR TITLE
refactor: イベント詳細表示用の重複クエリを整理する

### DIFF
--- a/app/controllers/concerns/event_show_resources.rb
+++ b/app/controllers/concerns/event_show_resources.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module EventShowResources
+  extend ActiveSupport::Concern
+
+  private
+
+  def load_event_show_resources
+    @participating = user_signed_in? && @event.event_participants.exists?(user_id: current_user.id)
+    @participants = @event.participants
+    @current_sort = current_event_show_sort
+    @shops = event_show_shops
+    @top_shops = @event.shops.order(likes_count: :desc, created_at: :asc).limit(self.class::TOP_SHOPS_LIMIT)
+    @event_preferences = @event.event_preferences.order(updated_at: :desc)
+  end
+
+  def current_event_show_sort
+    params[:sort] == "likes_count" ? "likes_count" : "created_at"
+  end
+
+  def event_show_shops
+    case @current_sort
+    when "likes_count"
+      @event.shops.includes(:user, :likes).order(likes_count: :desc, created_at: :asc)
+    else
+      @event.shops.includes(:user, :likes).order(created_at: :asc)
+    end
+  end
+end

--- a/app/controllers/event_preferences_controller.rb
+++ b/app/controllers/event_preferences_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EventPreferencesController < ApplicationController
+  include EventShowResources
+
   TOP_SHOPS_LIMIT = 3
 
   before_action :authenticate_user!
@@ -40,20 +42,5 @@ class EventPreferencesController < ApplicationController
 
   def event_preference_params
     params.require(:event_preference).permit(:dislike_foods, :budget, :content)
-  end
-
-  def load_event_show_resources
-    @participating = true
-    @participants = @event.participants
-    @current_sort = params[:sort] == "likes_count" ? "likes_count" : "created_at"
-    @shops =
-      case @current_sort
-      when "likes_count"
-        @event.shops.includes(:user, :likes).order(likes_count: :desc, created_at: :asc)
-      else
-        @event.shops.includes(:user, :likes).order(created_at: :asc)
-      end
-    @top_shops = @event.shops.order(likes_count: :desc, created_at: :asc).limit(TOP_SHOPS_LIMIT)
-    @event_preferences = @event.event_preferences.order(updated_at: :desc)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EventsController < ApplicationController
+  include EventShowResources
+
   TOP_SHOPS_LIMIT = 3
 
   before_action :authenticate_user!, except: %i[join]
@@ -20,19 +22,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @participating = user_signed_in? && @event.event_participants.exists?(user_id: current_user.id)
-    @participants = @event.participants
-    @current_sort = params[:sort] == "likes_count" ? "likes_count" : "created_at"
-    # 並び替え用
-    @shops =
-      case @current_sort
-      when "likes_count"
-        @event.shops.includes(:user, :likes).order(likes_count: :desc, created_at: :asc)
-      else
-        @event.shops.includes(:user, :likes).order(created_at: :asc)
-      end
-    # ランキング用
-    @top_shops = @event.shops.order(likes_count: :desc, created_at: :asc).limit(TOP_SHOPS_LIMIT)
+    load_event_show_resources
 
     # 希望条件フォーム用
     @event_preference =
@@ -41,9 +31,6 @@ class EventsController < ApplicationController
       else
         EventPreference.new
       end
-
-    # 希望条件一覧用
-    @event_preferences = @event.event_preferences.order(updated_at: :desc)
   end
 
   def join


### PR DESCRIPTION
## 概要
イベント詳細画面に必要な共通データ読み込みを concern に切り出し、`EventsController` と `EventPreferencesController` に重複していた処理を整理した。

## 実装内容
- `EventShowResources` concern を追加
- `EventsController#show` の共通データ読み込みを concern 利用に変更
- `EventPreferencesController` の重複していた読み込み処理を concern 利用に変更
- `show` 固有の `@event_preference` は `EventsController` 側に残し、責務を分けた

## 動作確認
- [x] `docker compose run --rm web bash -lc "bundle exec rails db:prepare && bundle exec rspec spec/requests/events_spec.rb spec/requests/event_preferences_spec.rb spec/system/event_preferences_spec.rb spec/system/events_spec.rb"`
- [x] `docker compose run --rm web bash -lc "bundle exec rubocop app/controllers/concerns/event_show_resources.rb app/controllers/events_controller.rb app/controllers/event_preferences_controller.rb"`

## 補足
- 講師フィードバックで指摘のあった `EventsController#show` と `EventPreferencesController` の重複クエリ整理に対応
- 共通化しつつ、`show` 固有のフォーム用データは無理にまとめず controller 側に残した

Closes #162 
