### PR TITLE
refactor: 希望条件の予算値をenumで整理する

### DIFF
--- a/app/models/event_preference.rb
+++ b/app/models/event_preference.rb
@@ -4,22 +4,17 @@ class EventPreference < ApplicationRecord
   belongs_to :event
   belongs_to :user
 
+  enum :budget, {
+    one: 1,
+    two: 2,
+    three: 3,
+    four: 4,
+    five: 5
+  }, prefix: true
+
   validates :user_id, uniqueness: { scope: :event_id }
 
   def budget_label
-    case budget
-    when 1
-      I18n.t("models.event_preference.budget_labels.one")
-    when 2
-      I18n.t("models.event_preference.budget_labels.two")
-    when 3
-      I18n.t("models.event_preference.budget_labels.three")
-    when 4
-      I18n.t("models.event_preference.budget_labels.four")
-    when 5
-      I18n.t("models.event_preference.budget_labels.five")
-    else
-      I18n.t("models.event_preference.budget_labels.unset")
-    end
+    I18n.t("models.event_preference.budget_labels.#{budget || 'unset'}")
   end
 end

--- a/app/views/events/_preferences.html.erb
+++ b/app/views/events/_preferences.html.erb
@@ -134,11 +134,11 @@
                 <%= f.select :budget,
                   [
                     [t("views.events.preferences.select_budget"), nil],
-                    [t("views.events.preferences.option_1"), 1],
-                    [t("views.events.preferences.option_2"), 2],
-                    [t("views.events.preferences.option_3"), 3],
-                    [t("views.events.preferences.option_4"), 4],
-                    [t("views.events.preferences.option_5"), 5]
+                    [t("views.events.preferences.option_1"), "one"],
+                    [t("views.events.preferences.option_2"), "two"],
+                    [t("views.events.preferences.option_3"), "three"],
+                    [t("views.events.preferences.option_4"), "four"],
+                    [t("views.events.preferences.option_5"), "five"]
                   ],
                   {},
                   class: "select select-bordered w-full rounded-2xl bg-base-100" %>

--- a/spec/factories/event_preferences.rb
+++ b/spec/factories/event_preferences.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :event
     association :user
     dislike_foods { "none" }
-    budget { 3 }
+    budget { :three }
     content { "preference note" }
   end
 end

--- a/spec/models/event_preference_spec.rb
+++ b/spec/models/event_preference_spec.rb
@@ -1,6 +1,18 @@
 require "rails_helper"
 
 RSpec.describe EventPreference, type: :model do
+  describe "enum定義" do
+    it "budgetの値に意味のある名前を持たせていること" do
+      expect(described_class.budgets).to eq(
+        "one" => 1,
+        "two" => 2,
+        "three" => 3,
+        "four" => 4,
+        "five" => 5
+      )
+    end
+  end
+
   describe "バリデーション" do
     it "有効なfactoryを持つこと" do
       expect(build(:event_preference)).to be_valid
@@ -30,34 +42,18 @@ RSpec.describe EventPreference, type: :model do
   end
 
   describe "#budget_label" do
-    it "budgetが1のとき対応する文言を返すこと" do
-      event_preference = build(:event_preference, budget: 1)
+    {
+      one: "one",
+      two: "two",
+      three: "three",
+      four: "four",
+      five: "five"
+    }.each do |budget_value, budget_label_key|
+      it "budgetが#{budget_value}のとき対応する文言を返すこと" do
+        event_preference = build(:event_preference, budget: budget_value)
 
-      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.one"))
-    end
-
-    it "budgetが2のとき対応する文言を返すこと" do
-      event_preference = build(:event_preference, budget: 2)
-
-      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.two"))
-    end
-
-    it "budgetが3のとき対応する文言を返すこと" do
-      event_preference = build(:event_preference, budget: 3)
-
-      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.three"))
-    end
-
-    it "budgetが4のとき対応する文言を返すこと" do
-      event_preference = build(:event_preference, budget: 4)
-
-      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.four"))
-    end
-
-    it "budgetが5のとき対応する文言を返すこと" do
-      event_preference = build(:event_preference, budget: 5)
-
-      expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.five"))
+        expect(event_preference.budget_label).to eq(I18n.t("models.event_preference.budget_labels.#{budget_label_key}"))
+      end
     end
 
     it "想定外の値なら未設定文言を返すこと" do

--- a/spec/requests/event_preferences_spec.rb
+++ b/spec/requests/event_preferences_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "EventPreferences", type: :request do
       {
         event_preference: {
           dislike_foods: "none",
-          budget: 3,
+          budget: "three",
           content: "memo"
         }
       }
@@ -43,7 +43,7 @@ RSpec.describe "EventPreferences", type: :request do
       sign_in participant
 
       expect {
-        post event_event_preferences_path(event), params: { event_preference: { content: "after", budget: 4 } }
+        post event_event_preferences_path(event), params: { event_preference: { content: "after", budget: "four" } }
       }.not_to change(EventPreference, :count)
 
       expect(response).to redirect_to(event_path(event))


### PR DESCRIPTION
## 概要
`EventPreference#budget_label` の `case` 文を整理し、予算値を enum で意味付けする形に変更した。

## 実装内容
- `EventPreference` に `budget` の enum を追加
- `budget_label` を enum 名 + i18n で文言を返す実装に変更
- 希望条件フォームの `budget` 選択肢の値を enum キーに変更
- request spec / system spec / factory を enum 前提に合わせて整理
- model spec に enum 定義の確認を追加

## 動作確認
- [x] `docker compose run --rm web bash -lc "bundle exec rails db:prepare && bundle exec rspec spec/models/event_preference_spec.rb spec/requests/event_preferences_spec.rb spec/system/event_preferences_spec.rb"`
- [x] `docker compose run --rm web bash -lc "bundle exec rubocop app/models/event_preference.rb spec/models/event_preference_spec.rb spec/requests/event_preferences_spec.rb spec/system/event_preferences_spec.rb spec/factories/event_preferences.rb"`
- [x] ブラウザで希望条件フォームの表示・保存・予算ラベル表示を確認

## 補足
- 講師フィードバックの `budget_label` 整理に対応
- 整数値のままだと意味が見えにくかったため、enum で意味付けし、表示文言は i18n に分離した
- フォーム送信値も enum キーにそろえて、入力から表示まで一貫した形に整理した

Closes #163 
