### PR TITLE
feat: Resendでパスワード再設定メール送信を再公開する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "devise"
 
 gem "devise-i18n"
 gem "rails-i18n"
+gem "resend"
 
 gem "omniauth-line-v2"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -143,6 +144,10 @@ GEM
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -318,6 +323,9 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.3.0)
+      base64
+      httparty (>= 0.22.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -454,6 +462,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.6)
   rails-i18n
+  resend
   rspec-rails
   rubocop
   rubocop-rails
@@ -494,6 +503,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   devise (5.0.2) sha256=254330c9290e612ad9681e8a18c96aa21fb95bc391af936b84480965444bb0b6
@@ -510,6 +520,7 @@ CHECKSUMS
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
+  httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.16.0) sha256=2abe56c9ac947cdcb2f150572904ba798c1e93c890c256f8429981a7675b0806
@@ -583,6 +594,7 @@ CHECKSUMS
   rdoc (7.0.3) sha256=dfe3d0981d19b7bba71d9dbaeb57c9f4e3a7a4103162148a559c4fc687ea81f9
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  resend (1.3.0) sha256=e9e141b0a14cd060e2dac70c552a2f6e688d601f7af5bb47f874b473949d0d1d
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,5 @@
 class Users::PasswordsController < Devise::PasswordsController
   before_action :redirect_if_authenticated, only: %i[new edit]
-  before_action :redirect_unreleased_password_reset, only: %i[new create edit update]
 
   private
 
@@ -8,10 +7,5 @@ class Users::PasswordsController < Devise::PasswordsController
     return unless user_signed_in?
 
     redirect_to dashboard_path, alert: t("flash.devise.already_authenticated.alert")
-  end
-
-  def redirect_unreleased_password_reset
-    redirect_to new_user_session_path,
-      alert: t("flash.devise.password_reset_unavailable.alert")
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,6 +34,9 @@
             </div>
 
             <div class="flex items-center justify-end pt-1">
+              <%= link_to t("views.devise.shared.links.forgot_password"),
+                new_user_password_path,
+                class: "text-sm font-medium text-[#8b5a3c] hover:text-[#6f452c] underline underline-offset-2" %>
             </div>
 
             <div class="pt-1">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,22 +75,12 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("MAILER_HOST", "gohankaigi.com"),
+    host: ENV.fetch("APP_HOST", "gohankaigi.com"),
     protocol: "https"
   }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :resend
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-
-  config.action_mailer.smtp_settings = {
-    address: "smtp.sendgrid.net",
-    port: 587,
-    domain: ENV.fetch("MAILER_HOST", "gohankaigi.com"),
-    user_name: "apikey",
-    password: ENV.fetch("SENDGRID_API_KEY"),
-    authentication: :plain,
-    enable_starttls_auto: true
-  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch("MAILER_FROM", "no-reply@gohankaigi.com")
+  config.mailer_sender = ENV.fetch("MAIL_FROM", "no-reply@gohankaigi.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+if Rails.env.production?
+  Resend.api_key = ENV.fetch("RESEND_API_KEY")
+end

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Users::Passwords", type: :request do
   describe "GET /users/password/new" do
-    it "未ログイン時はログイン画面へリダイレクトされること" do
+    it "未ログイン時は画面を表示できること" do
       get new_user_password_path
 
-      expect(response).to redirect_to(new_user_session_path)
+      expect(response).to have_http_status(:ok)
     end
 
     it "ログイン済みならdashboardへリダイレクトされること" do
@@ -19,18 +19,19 @@ RSpec.describe "Users::Passwords", type: :request do
   end
 
   describe "POST /users/password" do
-    it "未ログイン時はログイン画面へリダイレクトされること" do
+    it "未ログイン時でもメール送信処理を開始できること" do
       post user_password_path, params: { user: { email: "test@example.com" } }
 
       expect(response).to redirect_to(new_user_session_path)
+      expect(flash[:notice]).to be_present
     end
   end
 
   describe "GET /users/password/edit" do
-    it "未ログイン時はログイン画面へリダイレクトされること" do
+    it "未ログイン時でもトークン付きなら画面を表示できること" do
       get edit_user_password_path, params: { reset_password_token: "token" }
 
-      expect(response).to redirect_to(new_user_session_path)
+      expect(response).to have_http_status(:ok)
     end
 
     it "ログイン済みならdashboardへリダイレクトされること" do


### PR DESCRIPTION
## 概要
本番環境のパスワード再設定メール送信を Resend 方式へ切り替え、一時的に閉じていた再設定導線を再公開した。

## 実装内容
- `resend` gem を追加
- `config/initializers/resend.rb` を追加し、本番環境で `RESEND_API_KEY` を設定
- `production.rb` のメール送信方式を SendGrid SMTP から `:resend` に変更
- mailer 関連の環境変数を `APP_HOST` / `MAIL_FROM` ベースへ整理
- `Users::PasswordsController` の一時停止処理を削除
- `spec/requests/users/passwords_spec.rb` を通常の Devise 挙動に合わせて更新
- ログイン画面に「パスワードを忘れた方」リンクを復旧

## 動作確認
- [x] `bundle install`
- [x] `bundle exec rspec spec/requests/users/passwords_spec.rb`
- [x] `bundle exec rubocop Gemfile config/initializers/resend.rb config/environments/production.rb config/initializers/devise.rb app/controllers/users/passwords_controller.rb app/views/devise/sessions/new.html.erb spec/requests/users/passwords_spec.rb`
- [x] 開発環境でログイン画面に forgot password リンクが表示されることを確認
- [x] Resend で `gohankaigi.com` のドメイン認証が `Verified` になることを確認

## 補足
- 以前の Gmail / SendGrid SMTP 方式では Render Free 環境で timeout が発生していたため、SMTP を使わない Resend API 方式へ切り替えた
- 本PRマージ後は Render 本番でメール送信からパスワード再設定完了まで E2E 確認を行う

Closes #155
