### PR TITLE
fix: イベント詳細メモ欄のスマホ表示位置を調整する

### DIFF
--- a/app/views/events/_event_header.html.erb
+++ b/app/views/events/_event_header.html.erb
@@ -67,9 +67,7 @@
           <span><%= t("views.events.show.note") %></span>
         </div>
 
-        <p class="text-base leading-relaxed text-base-content/80 whitespace-pre-wrap">
-          <%= event.note %>
-        </p>
+        <p class="text-base leading-relaxed text-base-content/80 whitespace-pre-wrap"><%= event.note.to_s.strip %></p>
       </div>
     <% end %>
 


### PR DESCRIPTION
## 概要
イベント詳細画面のメモ欄がスマホ表示で不自然な位置から始まって見えていたため、本文出力を調整して自然に読める見え方へ改善した。

## 実装内容
- `app/views/events/_event_header.html.erb` のメモ本文出力を1行に整理
- `whitespace-pre-wrap` と ERB テンプレート内の改行・インデントが表示に影響しないよう調整
- PC表示の見え方は維持しつつ、スマホでの本文開始位置を改善

## 動作確認
- [x] 開発環境のスマホ表示でメモ本文が自然な位置から始まることを確認
- [x] PC表示の見え方が大きく崩れていないことを確認

## 補足
- 余白や文字サイズ調整では改善せず、最終的に本文出力方法が原因だったため修正方針を切り替えた
- `whitespace-pre-wrap` 使用時にテンプレート空白が見え方へ影響するケースの対応

Closes #170 